### PR TITLE
fix(rpc): fall through to CometBFT on KV indexer miss to serve derive…

### DIFF
--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -520,7 +520,11 @@ func (b *Backend) RPCBlockFromCometBlock(
 			rpcTx, err = rpctypes.NewRPCTransactionFromIncompleteMsg(ethMsg, common.BytesToHash(block.Hash()), height, index, baseFee, b.EvmChainID, txsAdditional[txIndex].Hash)
 		}
 		if err != nil {
-			b.Logger.Debug("NewTransactionFromData for receipt failed", "hash", ethMsg.Hash(), "error", err.Error())
+			logHash := ethMsg.Hash()
+			if txsAdditional[txIndex] != nil {
+				logHash = txsAdditional[txIndex].Hash
+			}
+			b.Logger.Debug("NewTransactionFromData for receipt failed", "hash", logHash, "error", err.Error())
 			continue
 		}
 		ethRPCTxs = append(ethRPCTxs, rpcTx)
@@ -661,22 +665,29 @@ func (b *Backend) GetBlockReceipts(
 		return nil, fmt.Errorf("block result not found for height %d", resBlock.Block.Height)
 	}
 
-	msgs, _ := b.EthMsgsFromCometBlock(resBlock, blockRes)
+	msgs, txsAdditional := b.EthMsgsFromCometBlock(resBlock, blockRes)
 	result := make([]map[string]interface{}, len(msgs))
 	blockHash := common.BytesToHash(resBlock.Block.Header.Hash()).Hex()
 	for i, msg := range msgs {
-		txResult, _, err := b.GetTxByEthHash(msg.Hash())
-		if err != nil {
-			return nil, fmt.Errorf("tx not found: hash=%s, error=%s", msg.Hash(), err.Error())
+		// For derived txs use the original event hash — the reconstructed LegacyTx
+		// hash from msg.Hash() won't be found by either the KV index or CometBFT.
+		var lookupHash common.Hash
+		if txsAdditional[i] != nil {
+			lookupHash = txsAdditional[i].Hash
+		} else {
+			lookupHash = msg.Hash()
 		}
-		result[i], err = b.formatTxReceipt(
-			msg,
-			txResult,
-			blockRes,
-			blockHash,
-		)
+		txResult, _, err := b.GetTxByEthHash(lookupHash)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get transaction receipt for tx %s: %w", msg.Hash().Hex(), err)
+			return nil, fmt.Errorf("tx not found: hash=%s, error=%s", lookupHash, err.Error())
+		}
+		result[i], err = b.formatTxReceipt(msg, txResult, blockRes, blockHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get transaction receipt for tx %s: %w", lookupHash.Hex(), err)
+		}
+		// Override transactionHash for derived txs — same reason as in GetTransactionReceipt.
+		if txsAdditional[i] != nil {
+			result[i]["transactionHash"] = txsAdditional[i].Hash
 		}
 	}
 

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -352,16 +352,23 @@ func (b *Backend) parseDerivedTxFromAdditionalFields(
 	recipient := additional.Recipient
 	gas := gasForDerivedEthTx(additional)
 
-	t := ethtypes.NewTx(&ethtypes.LegacyTx{
-		Nonce:    additional.Nonce,
-		Data:     additional.Data,
-		Gas:      gas,
-		To:       &recipient,
-		GasPrice: nil,
-		Value:    additional.Value,
-		V:        big.NewInt(0),
-		R:        big.NewInt(0),
-		S:        big.NewInt(0),
+	// Reconstruct as EIP-1559 (type 0x2) so clients receive yParity and the
+	// correct typed-tx format. GasFeeCap and GasTipCap are zero because the
+	// original fee values are not stored in the derived-tx events; the externally
+	// visible hash is always overridden with additional.Hash at the call site so
+	// the reconstructed hash here does not affect RPC consistency.
+	t := ethtypes.NewTx(&ethtypes.DynamicFeeTx{
+		ChainID:   b.EvmChainID,
+		Nonce:     additional.Nonce,
+		Data:      additional.Data,
+		Gas:       gas,
+		To:        &recipient,
+		Value:     additional.Value,
+		GasFeeCap: big.NewInt(0),
+		GasTipCap: big.NewInt(0),
+		V:         big.NewInt(0),
+		R:         big.NewInt(0),
+		S:         big.NewInt(0),
 	})
 	ethMsg := &evmtypes.MsgEthereumTx{}
 	ethMsg.FromEthereumTx(t)

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -491,7 +491,14 @@ func (b *Backend) RPCBlockFromCometBlock(
 	msgs, txsAdditional := b.EthMsgsFromCometBlock(resBlock, blockRes)
 	for txIndex, ethMsg := range msgs {
 		if !fullTx {
-			hash := ethMsg.Hash()
+			// For derived txs use the original event hash, not the reconstructed
+			// LegacyTx hash, so hash-only and full-tx block responses agree.
+			var hash common.Hash
+			if txsAdditional[txIndex] != nil {
+				hash = txsAdditional[txIndex].Hash
+			} else {
+				hash = ethMsg.Hash()
+			}
 			ethRPCTxs = append(ethRPCTxs, hash)
 			continue
 		}

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -6,7 +6,6 @@ import (
 	"math"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
@@ -268,29 +267,10 @@ func (b *Backend) TraceBlock(height rpctypes.BlockNumber,
 		b.Logger.Debug("block result not found", "height", block.Block.Height, "error", err.Error())
 		return nil, nil
 	}
-	txDecoder := b.ClientCtx.TxConfig.TxDecoder()
 
-	var txsMessages []*evmtypes.MsgEthereumTx
-	for i, tx := range txs {
-		if !rpctypes.TxSucessOrExpectedFailure(blockRes.TxsResults[i]) {
-			b.Logger.Debug("invalid tx result code", "cosmos-hash", hexutil.Encode(tx.Hash()))
-			continue
-		}
-		decodedTx, err := txDecoder(tx)
-		if err != nil {
-			b.Logger.Error("failed to decode transaction", "hash", txs[i].Hash(), "error", err.Error())
-			continue
-		}
-
-		for _, msg := range decodedTx.GetMsgs() {
-			ethMessage, ok := msg.(*evmtypes.MsgEthereumTx)
-			if !ok {
-				// Just considers Ethereum transactions
-				continue
-			}
-			txsMessages = append(txsMessages, ethMessage)
-		}
-	}
+	// EthMsgsFromCometBlock returns both native MsgEthereumTx and derived txs so
+	// that TraceBlock covers the full set of EVM-visible transactions in the block.
+	txsMessages, _ := b.EthMsgsFromCometBlock(block, blockRes)
 
 	// minus one to get the context at the beginning of the block
 	contextHeight := height - 1

--- a/rpc/backend/tracing_derived_test.go
+++ b/rpc/backend/tracing_derived_test.go
@@ -1,0 +1,190 @@
+package backend_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/evm/encoding"
+	"github.com/cosmos/evm/rpc/backend"
+	"github.com/cosmos/evm/rpc/backend/mocks"
+	rpctypes "github.com/cosmos/evm/rpc/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	"cosmossdk.io/log"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// minimalEncodedTx returns valid Cosmos tx bytes that decode to a tx with zero
+// messages. TraceTransaction needs decodable bytes at blk.Block.Txs[TxIndex]
+// even for derived txs; the messages are never accessed in the success path.
+func minimalEncodedTx(t *testing.T) []byte {
+	t.Helper()
+	cfg := encoding.MakeConfig(1)
+	txb := cfg.TxConfig.NewTxBuilder()
+	bz, err := cfg.TxConfig.TxEncoder()(txb.GetTx())
+	require.NoError(t, err)
+	return bz
+}
+
+// derivedBlockResults returns ResultBlockResults whose TxsResults[0] carries
+// the same ethereum_tx events that a derived tx emits on chain.
+func derivedBlockResults(hash common.Hash, sender, recipient common.Address) *coretypes.ResultBlockResults {
+	attrs := []abci.EventAttribute{
+		{Key: "amount", Value: "0"},
+		{Key: evmtypes.AttributeKeyEthereumTxHash, Value: hash.Hex()},
+		{Key: evmtypes.AttributeKeyTxIndex, Value: fmt.Sprintf("%d", evmtypes.DerivedTxIndex)},
+		{Key: evmtypes.AttributeKeyTxGasUsed, Value: "21000"},
+		{Key: evmtypes.AttributeKeyRecipient, Value: recipient.Hex()},
+		{Key: evmtypes.AttributeKeyTxData, Value: "0x"},
+		{Key: evmtypes.AttributeKeyTxNonce, Value: "0"},
+		{Key: evmtypes.AttributeKeyTxGasLimit, Value: "100000"},
+	}
+	msgAttrs := []abci.EventAttribute{
+		{Key: string(sdk.AttributeKeySender), Value: sender.Hex()},
+		{Key: evmtypes.AttributeKeyTxType, Value: fmt.Sprintf("%d", evmtypes.DerivedTxType)},
+	}
+	return &coretypes.ResultBlockResults{
+		Height: 100,
+		TxsResults: []*abci.ExecTxResult{
+			{
+				Code: 0,
+				Events: []abci.Event{
+					{Type: evmtypes.EventTypeEthereumTx, Attributes: attrs},
+					{Type: "message", Attributes: msgAttrs},
+				},
+				GasUsed: 21000,
+			},
+		},
+	}
+}
+
+// TestTraceTransaction_DerivedTx is the end-to-end test for debug_traceTransaction
+// on a derived tx hash. It verifies that:
+//   - GetTxByEthHash falls through to CometBFT when the KV index misses
+//   - TraceTransaction correctly builds the ethMessage from additional fields
+//   - TraceTx gRPC is called with the right Msg (correct sender / recipient)
+//   - The trace result is returned without error
+func TestTraceTransaction_DerivedTx(t *testing.T) {
+	derivedHash := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	sender := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	recipient := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	height := int64(100)
+
+	txBytes := minimalEncodedTx(t)
+
+	mockClient := mocks.NewClient(t)
+	mockEVMQueryClient := mocks.NewEVMQueryClient(t)
+
+	// 1. GetTxByEthHash: KV miss → TxSearch finds it
+	expectedQuery := fmt.Sprintf("%s.%s='%s'",
+		evmtypes.TypeMsgEthereumTx,
+		evmtypes.AttributeKeyEthereumTxHash,
+		derivedHash.Hex(),
+	)
+	mockClient.On("TxSearch",
+		mock.Anything, expectedQuery, false,
+		(*int)(nil), (*int)(nil), "",
+	).Return(derivedTxSearchResult(derivedHash, sender, recipient), nil)
+
+	// 2. CometBlockByNumber: returns block containing our encoded tx
+	mockClient.On("Block", mock.Anything, &height).
+		Return(&coretypes.ResultBlock{
+			Block: &cmttypes.Block{
+				Header: cmttypes.Header{Height: height},
+				Data:   cmttypes.Data{Txs: cmttypes.Txs{txBytes}},
+			},
+		}, nil)
+
+	// 3. BlockResults: called twice — once in the additional!=nil branch
+	//    (to find in-tx predecessors) and once in formatTxReceipt if reached.
+	//    We use .Maybe() so extra calls are silently ignored.
+	mockClient.On("BlockResults", mock.Anything, &height).
+		Return(derivedBlockResults(derivedHash, sender, recipient), nil).Maybe()
+
+	// 4. ConsensusParams: required for BlockMaxGas in TraceTxRequest
+	mockClient.On("ConsensusParams", mock.Anything, &height).
+		Return(&coretypes.ResultConsensusParams{
+			ConsensusParams: cmttypes.ConsensusParams{
+				Block: cmttypes.BlockParams{MaxGas: 10_000_000},
+			},
+		}, nil)
+
+	// 5. TraceTx: the gRPC call that actually runs the trace
+	traceOutput := `{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}`
+	mockEVMQueryClient.On("TraceTx", mock.Anything, mock.MatchedBy(func(req *evmtypes.QueryTraceTxRequest) bool {
+		// Core assertions on what TraceTransaction sends to the EVM module:
+		// - Msg must be non-nil (reconstructed from additional fields)
+		// - Predecessors must be empty (single derived tx, TxIndex=0)
+		// - Block height must match
+		return req.Msg != nil &&
+			len(req.Predecessors) == 0 &&
+			req.BlockNumber == height
+	}), mock.Anything).
+		Return(&evmtypes.QueryTraceTxResponse{Data: []byte(traceOutput)}, nil)
+
+	// 6. Params: BlockNumber() calls this; returning error makes ChainID() fall back to EvmChainID
+	mockEVMQueryClient.On("Params", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, errors.New("no connection")).Maybe()
+
+	cfg := encoding.MakeConfig(1)
+	b := &backend.Backend{
+		Ctx:         context.Background(),
+		Indexer:     &stubIndexer{},
+		Logger:      log.NewNopLogger(),
+		EvmChainID:  big.NewInt(1),
+		RPCClient:   mockClient,
+		ClientCtx:   client.Context{Client: mockClient, TxConfig: cfg.TxConfig},
+		QueryClient: &rpctypes.QueryClient{QueryClient: mockEVMQueryClient},
+	}
+
+	result, err := b.TraceTransaction(derivedHash, nil)
+
+	require.NoError(t, err, "TraceTransaction should succeed for a derived tx")
+	require.NotNil(t, result, "trace result must not be nil")
+
+	// Verify the trace output is what TraceTx returned
+	resultBytes, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.Contains(t, string(resultBytes), "structLogs",
+		"trace result should contain structLogs from the TraceTx response")
+}
+
+// TestTraceTransaction_DerivedTxNotFound verifies that when neither the KV index
+// nor CometBFT can find the derived hash, TraceTransaction returns an error.
+func TestTraceTransaction_DerivedTxNotFound(t *testing.T) {
+	unknownHash := common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+
+	mockClient := mocks.NewClient(t)
+
+	// TxSearch finds nothing
+	mockClient.On("TxSearch", mock.Anything, mock.Anything, false,
+		(*int)(nil), (*int)(nil), "").
+		Return(&coretypes.ResultTxSearch{Txs: nil, TotalCount: 0}, nil)
+
+	b := &backend.Backend{
+		Ctx:        context.Background(),
+		Indexer:    &stubIndexer{},
+		Logger:     log.NewNopLogger(),
+		EvmChainID: big.NewInt(1),
+		RPCClient:  mockClient,
+		ClientCtx:  client.Context{Client: mockClient},
+	}
+
+	result, err := b.TraceTransaction(unknownHash, nil)
+
+	require.Error(t, err, "unknown derived hash should return an error")
+	require.Nil(t, result)
+}

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -216,7 +216,17 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash) (map[string]interface{
 	}
 
 	blockHeaderHash := common.BytesToHash(resBlock.Block.Header.Hash()).Hex()
-	return b.formatTxReceipt(ethMsg, res, blockRes, blockHeaderHash)
+	result, err := b.formatTxReceipt(ethMsg, res, blockRes, blockHeaderHash)
+	if err != nil {
+		return nil, err
+	}
+	// formatTxReceipt uses ethMsg.Hash() which for derived txs is the hash of a
+	// reconstructed LegacyTx — different from the original event hash. Override
+	// so that eth_getTransactionReceipt and eth_getBlockByNumber agree.
+	if additional != nil {
+		result["transactionHash"] = additional.Hash
+	}
+	return result, nil
 }
 
 // GetTransactionLogs returns the transaction logs identified by hash.

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -291,10 +291,11 @@ func (b *Backend) GetTransactionByBlockNumberAndIndex(blockNum rpctypes.BlockNum
 func (b *Backend) GetTxByEthHash(hash common.Hash) (*types.TxResult, *rpctypes.TxResultAdditionalFields, error) {
 	if b.Indexer != nil {
 		txRes, err := b.Indexer.GetByTxHash(hash)
-		if err != nil {
-			return nil, nil, err
+		if err == nil {
+			return txRes, nil, nil
 		}
-		return txRes, nil, nil
+		// KV miss — fall through to CometBFT. Derived txs are never written to
+		// the KV index but do emit ethereum_tx events, so CometBFT can serve them.
 	}
 
 	// fallback to CometBFT tx indexer
@@ -311,10 +312,10 @@ func (b *Backend) GetTxByEthHash(hash common.Hash) (*types.TxResult, *rpctypes.T
 func (b *Backend) GetTxByEthHashAndMsgIndex(hash common.Hash, index int) (*types.TxResult, *rpctypes.TxResultAdditionalFields, error) {
 	if b.Indexer != nil {
 		txRes, err := b.Indexer.GetByTxHash(hash)
-		if err != nil {
-			return nil, nil, err
+		if err == nil {
+			return txRes, nil, nil
 		}
-		return txRes, nil, nil
+		// KV miss — fall through to CometBFT for derived txs.
 	}
 
 	// fallback to CometBFT tx indexer

--- a/rpc/backend/tx_info_derived_test.go
+++ b/rpc/backend/tx_info_derived_test.go
@@ -213,10 +213,13 @@ func buildBackendForReceipt(
 			},
 		}, nil)
 
-	// 4. EVMQueryClient.Params — BlockNumber() calls this; returning an error
-	//    makes ChainID() fall back to b.EvmChainID (safe, no gRPC needed).
+	// 4. EVMQueryClient mocks:
+	//    - Params: BlockNumber() calls this; error makes ChainID() fall back to EvmChainID
+	//    - BaseFee: formatTxReceipt calls this for DynamicFeeTx (type 0x2) effective gas price
 	mockEVMQueryClient := mocks.NewEVMQueryClient(t)
 	mockEVMQueryClient.On("Params", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, errors.New("no connection"))
+	mockEVMQueryClient.On("BaseFee", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("no connection"))
 
 	b := &backend.Backend{

--- a/rpc/backend/tx_info_derived_test.go
+++ b/rpc/backend/tx_info_derived_test.go
@@ -8,13 +8,15 @@ import (
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
-	cmttypes "github.com/cometbft/cometbft/types"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/evm/rpc/backend"
 	"github.com/cosmos/evm/rpc/backend/mocks"
+	rpctypes "github.com/cosmos/evm/rpc/types"
 	cosmosevmtypes "github.com/cosmos/evm/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
@@ -162,4 +164,133 @@ func (s *stubNativeIndexer) GetByTxHash(h common.Hash) (*cosmosevmtypes.TxResult
 }
 func (s *stubNativeIndexer) GetByBlockAndIndex(_ int64, _ int32) (*cosmosevmtypes.TxResult, error) {
 	return nil, errors.New("tx not found")
+}
+
+// ---------------------------------------------------------------------------
+// GetTransactionReceipt tests
+// ---------------------------------------------------------------------------
+
+// buildBackendForReceipt wires up a Backend with all dependencies needed to
+// exercise GetTransactionReceipt for a derived tx:
+//   - stubIndexer (KV always misses)
+//   - mockClient handles TxSearch, Block, BlockResults
+//   - mockEVMQueryClient.Params returns an error so ChainID() falls back to EvmChainID
+func buildBackendForReceipt(
+	t *testing.T,
+	derivedHash common.Hash,
+	sender, recipient common.Address,
+) (*backend.Backend, *mocks.Client) {
+	t.Helper()
+
+	mockClient := mocks.NewClient(t)
+
+	// 1. TxSearch — CometBFT finds the derived tx by hash
+	expectedQuery := fmt.Sprintf("%s.%s='%s'",
+		evmtypes.TypeMsgEthereumTx,
+		evmtypes.AttributeKeyEthereumTxHash,
+		derivedHash.Hex(),
+	)
+	mockClient.On("TxSearch",
+		mock.Anything, expectedQuery, false,
+		(*int)(nil), (*int)(nil), "",
+	).Return(derivedTxSearchResult(derivedHash, sender, recipient), nil)
+
+	// 2. Block — CometBlockByNumber fetches the block at height 100
+	height := int64(100)
+	mockClient.On("Block", mock.Anything, &height).
+		Return(&coretypes.ResultBlock{
+			Block: &cmttypes.Block{
+				Header: cmttypes.Header{Height: 100},
+			},
+		}, nil)
+
+	// 3. BlockResults — formatTxReceipt fetches block results at height 100
+	mockClient.On("BlockResults", mock.Anything, &height).
+		Return(&coretypes.ResultBlockResults{
+			Height: 100,
+			TxsResults: []*abci.ExecTxResult{
+				{Code: 0, GasUsed: 21000},
+			},
+		}, nil)
+
+	// 4. EVMQueryClient.Params — BlockNumber() calls this; returning an error
+	//    makes ChainID() fall back to b.EvmChainID (safe, no gRPC needed).
+	mockEVMQueryClient := mocks.NewEVMQueryClient(t)
+	mockEVMQueryClient.On("Params", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, errors.New("no connection"))
+
+	b := &backend.Backend{
+		Ctx:         context.Background(),
+		Indexer:     &stubIndexer{},
+		Logger:      log.NewNopLogger(),
+		EvmChainID:  big.NewInt(1),
+		RPCClient:   mockClient,
+		ClientCtx:   client.Context{Client: mockClient},
+		QueryClient: &rpctypes.QueryClient{QueryClient: mockEVMQueryClient},
+	}
+
+	return b, mockClient
+}
+
+// TestGetTransactionReceipt_DerivedTx is the end-to-end receipt test.
+// It verifies that after the fix a derived tx hash that is absent from the KV
+// index still produces a complete receipt via the CometBFT fallback path.
+func TestGetTransactionReceipt_DerivedTx(t *testing.T) {
+	derivedHash := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	sender := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	recipient := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	b, _ := buildBackendForReceipt(t, derivedHash, sender, recipient)
+
+	receipt, err := b.GetTransactionReceipt(derivedHash)
+
+	require.NoError(t, err)
+	require.NotNil(t, receipt, "receipt must not be nil — derived tx should now be resolvable")
+
+	// Core fields must be present
+	require.NotNil(t, receipt["transactionHash"], "transactionHash must be present")
+	require.NotNil(t, receipt["status"], "status must be present")
+	require.NotNil(t, receipt["blockNumber"], "blockNumber must be present")
+	require.NotNil(t, receipt["gasUsed"], "gasUsed must be present")
+
+	// Sender recovered from msg.From (set directly, no signature recovery needed)
+	require.Equal(t, sender, receipt["from"], "from address should match the derived tx sender")
+
+	// Recipient
+	to, ok := receipt["to"].(*common.Address)
+	require.True(t, ok, "to should be *common.Address")
+	require.Equal(t, recipient, *to, "to address should match the derived tx recipient")
+
+	// transactionIndex is DerivedTxIndex (9999) — known sentinel for derived txs
+	require.NotNil(t, receipt["transactionIndex"])
+}
+
+// TestGetTransactionReceipt_DerivedTxNotFound verifies that when neither the
+// KV index nor CometBFT can find the hash, the receipt returns nil (no crash).
+// GetTransactionReceipt returns early before ChainID() is called, so no
+// QueryClient mock is needed here.
+func TestGetTransactionReceipt_DerivedTxNotFound(t *testing.T) {
+	unknownHash := common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+
+	mockClient := mocks.NewClient(t)
+
+	// TxSearch finds nothing for the unknown hash
+	mockClient.On("TxSearch", mock.Anything, mock.Anything, false,
+		(*int)(nil), (*int)(nil), "").
+		Return(&coretypes.ResultTxSearch{Txs: nil, TotalCount: 0}, nil)
+
+	b := &backend.Backend{
+		Ctx:        context.Background(),
+		Indexer:    &stubIndexer{},
+		Logger:     log.NewNopLogger(),
+		EvmChainID: big.NewInt(1),
+		RPCClient:  mockClient,
+		ClientCtx:  client.Context{Client: mockClient},
+	}
+
+	receipt, err := b.GetTransactionReceipt(unknownHash)
+
+	// Must not crash — returns nil, nil per Ethereum spec for unknown hashes
+	require.NoError(t, err)
+	require.Nil(t, receipt, "unknown hash should return nil receipt, not an error")
 }

--- a/rpc/backend/tx_info_derived_test.go
+++ b/rpc/backend/tx_info_derived_test.go
@@ -1,0 +1,165 @@
+package backend_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/evm/rpc/backend"
+	"github.com/cosmos/evm/rpc/backend/mocks"
+	cosmosevmtypes "github.com/cosmos/evm/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	"cosmossdk.io/log"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// stubIndexer is a minimal EVMTxIndexer that always returns "not found".
+// This simulates a node with enable-indexer=true where derived txs are not stored.
+type stubIndexer struct{}
+
+func (s *stubIndexer) LastIndexedBlock() (int64, error)  { return 0, nil }
+func (s *stubIndexer) FirstIndexedBlock() (int64, error) { return 0, nil }
+func (s *stubIndexer) IndexBlock(_ *cmttypes.Block, _ []*abci.ExecTxResult) error { return nil }
+func (s *stubIndexer) GetByTxHash(_ common.Hash) (*cosmosevmtypes.TxResult, error) {
+	return nil, errors.New("tx not found")
+}
+func (s *stubIndexer) GetByBlockAndIndex(_ int64, _ int32) (*cosmosevmtypes.TxResult, error) {
+	return nil, errors.New("tx not found")
+}
+
+// derivedTxSearchResult builds a fake CometBFT TxSearch response containing
+// the ethereum_tx events that a derived tx emits (see x/vm/keeper/call_evm.go).
+func derivedTxSearchResult(hash common.Hash, sender, recipient common.Address) *coretypes.ResultTxSearch {
+	attrs := []abci.EventAttribute{
+		{Key: "amount", Value: "0"},
+		{Key: evmtypes.AttributeKeyEthereumTxHash, Value: hash.Hex()},
+		{Key: evmtypes.AttributeKeyTxIndex, Value: fmt.Sprintf("%d", evmtypes.DerivedTxIndex)},
+		{Key: evmtypes.AttributeKeyTxGasUsed, Value: "21000"},
+		{Key: evmtypes.AttributeKeyRecipient, Value: recipient.Hex()},
+		{Key: evmtypes.AttributeKeyTxData, Value: "0x"},
+		{Key: evmtypes.AttributeKeyTxNonce, Value: "0"},
+		{Key: evmtypes.AttributeKeyTxGasLimit, Value: "100000"},
+	}
+	msgAttrs := []abci.EventAttribute{
+		{Key: string(sdk.AttributeKeySender), Value: sender.Hex()},
+		{Key: evmtypes.AttributeKeyTxType, Value: fmt.Sprintf("%d", evmtypes.DerivedTxType)},
+	}
+
+	txResult := abci.ExecTxResult{
+		Code: 0,
+		Events: []abci.Event{
+			{Type: evmtypes.EventTypeEthereumTx, Attributes: attrs},
+			{Type: "message", Attributes: msgAttrs},
+		},
+	}
+
+	return &coretypes.ResultTxSearch{
+		Txs: []*coretypes.ResultTx{
+			{
+				Height:   100,
+				Index:    0,
+				TxResult: txResult,
+				Tx:       cmttypes.Tx{},
+			},
+		},
+		TotalCount: 1,
+	}
+}
+
+// TestGetTxByEthHash_DerivedTxFallthrough verifies the fix: when the KV indexer
+// returns "not found" for a derived tx hash, GetTxByEthHash falls through to
+// CometBFT and returns TxResultAdditionalFields (proof it found the derived tx).
+func TestGetTxByEthHash_DerivedTxFallthrough(t *testing.T) {
+	derivedHash := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	sender := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	recipient := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	// Mock CometBFT client: TxSearch finds the derived tx by its hash
+	mockClient := mocks.NewClient(t)
+	expectedQuery := fmt.Sprintf("%s.%s='%s'",
+		evmtypes.TypeMsgEthereumTx,
+		evmtypes.AttributeKeyEthereumTxHash,
+		derivedHash.Hex(),
+	)
+	mockClient.On("TxSearch",
+		context.Background(),
+		expectedQuery,
+		false, (*int)(nil), (*int)(nil), "",
+	).Return(derivedTxSearchResult(derivedHash, sender, recipient), nil)
+
+	b := &backend.Backend{
+		Ctx:       context.Background(),
+		Indexer:   &stubIndexer{},
+		Logger:    log.NewNopLogger(),
+		EvmChainID: big.NewInt(1),
+		ClientCtx: client.Context{Client: mockClient},
+	}
+
+	txResult, additional, err := b.GetTxByEthHash(derivedHash)
+
+	require.NoError(t, err, "derived tx lookup should succeed via CometBFT fallthrough")
+	require.NotNil(t, txResult, "TxResult should be populated")
+	require.NotNil(t, additional, "TxResultAdditionalFields must be non-nil for a derived tx")
+	require.Equal(t, uint64(evmtypes.DerivedTxType), additional.Type, "Type should be DerivedTxType (99)")
+	require.Equal(t, sender, additional.Sender, "Sender should match")
+	require.Equal(t, recipient, additional.Recipient, "Recipient should match")
+}
+
+// TestGetTxByEthHash_NativeTxKVHit verifies native txs still use the fast KV path
+// (i.e. the fallthrough does not affect native tx lookups).
+func TestGetTxByEthHash_NativeTxKVHit(t *testing.T) {
+	nativeHash := common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	// KV indexer returns a result for this hash (native tx)
+	kvResult := &cosmosevmtypes.TxResult{Height: 50, TxIndex: 1, EthTxIndex: 0}
+
+	nativeIndexer := &stubNativeIndexer{hash: nativeHash, result: kvResult}
+
+	// CometBFT client should NOT be called for native txs
+	mockClient := mocks.NewClient(t) // no .On() means any call panics
+
+	b := &backend.Backend{
+		Ctx:        context.Background(),
+		Indexer:    nativeIndexer,
+		Logger:     log.NewNopLogger(),
+		EvmChainID: big.NewInt(1),
+		ClientCtx:  client.Context{Client: mockClient},
+	}
+
+	txResult, additional, err := b.GetTxByEthHash(nativeHash)
+
+	require.NoError(t, err)
+	require.NotNil(t, txResult)
+	require.Nil(t, additional, "native tx should have no additional fields")
+	require.Equal(t, int64(50), txResult.Height)
+}
+
+// stubNativeIndexer returns a result for one specific hash (native tx), errors for everything else.
+type stubNativeIndexer struct {
+	hash   common.Hash
+	result *cosmosevmtypes.TxResult
+}
+
+func (s *stubNativeIndexer) LastIndexedBlock() (int64, error)  { return 0, nil }
+func (s *stubNativeIndexer) FirstIndexedBlock() (int64, error) { return 0, nil }
+func (s *stubNativeIndexer) IndexBlock(_ *cmttypes.Block, _ []*abci.ExecTxResult) error { return nil }
+func (s *stubNativeIndexer) GetByTxHash(h common.Hash) (*cosmosevmtypes.TxResult, error) {
+	if h == s.hash {
+		return s.result, nil
+	}
+	return nil, errors.New("tx not found")
+}
+func (s *stubNativeIndexer) GetByBlockAndIndex(_ int64, _ int32) (*cosmosevmtypes.TxResult, error) {
+	return nil, errors.New("tx not found")
+}

--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cometbft/cometbft/proto/tendermint/crypto"
 	cmtrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 
+	rpctypes "github.com/cosmos/evm/rpc/types"
 	"github.com/cosmos/evm/rpc/types"
 	cosmosevmtypes "github.com/cosmos/evm/types"
 	"github.com/cosmos/evm/utils"
@@ -226,6 +227,20 @@ func (b *Backend) ProcessBlock(
 				reward = big.NewInt(0)
 			}
 			sorter = append(sorter, txGasAndReward{gasUsed: txGasUsed, reward: reward})
+		}
+		// Also account for derived txs in this Cosmos tx (gasPrice=0, tip=0).
+		results, additionals, err := rpctypes.ParseTxBlockResult(cometTxResult, tx, i, blockHeight)
+		if err != nil {
+			continue
+		}
+		for j, additional := range additionals {
+			if additional == nil {
+				continue // native tx already handled above
+			}
+			sorter = append(sorter, txGasAndReward{
+				gasUsed: results[j].GasUsed,
+				reward:  big.NewInt(0), // derived txs pay no priority fee
+			})
 		}
 	}
 

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -280,24 +280,33 @@ func NewRPCTransactionFromIncompleteMsg(
 	from := msg.GetSender()
 	v, r, s := tx.RawSignatureValues()
 	result := &RPCTransaction{
-		Type:     hexutil.Uint64(tx.Type()),
-		From:     from,
-		Gas:      hexutil.Uint64(tx.Gas()),
-		GasPrice: (*hexutil.Big)(tx.GasPrice()),
-		Hash:     txHash,
-		Input:    hexutil.Bytes(tx.Data()),
-		Nonce:    hexutil.Uint64(tx.Nonce()),
-		To:       tx.To(),
-		Value:    (*hexutil.Big)(tx.Value()),
-		V:        (*hexutil.Big)(v),
-		R:        (*hexutil.Big)(r),
-		S:        (*hexutil.Big)(s),
-		ChainID:  (*hexutil.Big)(chainID),
+		Type:    hexutil.Uint64(tx.Type()),
+		From:    from,
+		Gas:     hexutil.Uint64(tx.Gas()),
+		Hash:    txHash,
+		Input:   hexutil.Bytes(tx.Data()),
+		Nonce:   hexutil.Uint64(tx.Nonce()),
+		To:      tx.To(),
+		Value:   (*hexutil.Big)(tx.Value()),
+		V:       (*hexutil.Big)(v),
+		R:       (*hexutil.Big)(r),
+		S:       (*hexutil.Big)(s),
+		ChainID: (*hexutil.Big)(chainID),
 	}
 	if blockHash != (common.Hash{}) {
 		result.BlockHash = &blockHash
 		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
 		result.TransactionIndex = (*hexutil.Uint64)(&index)
+		// Derived txs pay exactly the base fee — no priority tip. Set gasPrice to
+		// baseFee so Blockscout's reward formula (tx_fees - burnt_fees) yields 0
+		// instead of a negative number (which happens when gasPrice = 0).
+		if baseFee != nil {
+			result.GasPrice = (*hexutil.Big)(new(big.Int).Set(baseFee))
+		} else {
+			result.GasPrice = (*hexutil.Big)(tx.GasPrice())
+		}
+	} else {
+		result.GasPrice = (*hexutil.Big)(tx.GasPrice())
 	}
 	return result, nil
 }

--- a/x/vm/keeper/call_evm.go
+++ b/x/vm/keeper/call_evm.go
@@ -229,13 +229,12 @@ func (k Keeper) DerivedEVMCallWithData(
 	// thus restricted to be used only inside `ApplyMessage`.
 	tmpCtx, commitState := ctx.CacheContext()
 
-	// pass true to commit the StateDB
-	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, true, cfg, txConfig, true)
+	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, commit, cfg, txConfig, true)
 	if err != nil {
 		return nil, err
 	}
 
-	if !res.Failed() {
+	if commit && !res.Failed() {
 		commitState()
 	}
 
@@ -251,8 +250,7 @@ func (k Keeper) DerivedEVMCallWithData(
 			sdk.NewAttribute(sdk.AttributeKeyAmount, value.String()),
 			// add event for ethereum transaction hash format;
 			sdk.NewAttribute(types.AttributeKeyEthereumTxHash, ethTxHash),
-			// add event for index of valid ethereum tx; NOTE: default txindex for derivedTx
-			sdk.NewAttribute(types.AttributeKeyTxIndex, strconv.FormatUint(types.DerivedTxIndex, 10)),
+			sdk.NewAttribute(types.AttributeKeyTxIndex, strconv.FormatUint(uint64(txConfig.TxIndex), 10)),
 			// add event for eth tx gas used, we can't get it from cosmos tx result when it contains multiple eth tx msgs.
 			sdk.NewAttribute(types.AttributeKeyTxGasUsed, strconv.FormatUint(gasUsed, 10)),
 		}...)
@@ -263,16 +261,6 @@ func (k Keeper) DerivedEVMCallWithData(
 		}
 		if res.Failed() {
 			attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyEthereumTxFailed, res.VmError))
-		}
-
-		txLogAttrs := make([]sdk.Attribute, len(res.Logs))
-		for i, log := range res.Logs {
-			log.TxHash = ethTxHash
-			value, err := json.Marshal(log)
-			if err != nil {
-				return nil, errorsmod.Wrap(err, "failed to encode log")
-			}
-			txLogAttrs[i] = sdk.NewAttribute(types.AttributeKeyTxLog, string(value))
 		}
 
 		// adding txData for more info in rpc methods in order to parse derived txs
@@ -286,10 +274,6 @@ func (k Keeper) DerivedEVMCallWithData(
 				attrs...,
 			),
 			sdk.NewEvent(
-				types.EventTypeTxLog,
-				txLogAttrs...,
-			),
-			sdk.NewEvent(
 				sdk.EventTypeMessage,
 				sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
 				sdk.NewAttribute(sdk.AttributeKeySender, from.Hex()),
@@ -297,15 +281,36 @@ func (k Keeper) DerivedEVMCallWithData(
 			),
 		})
 
-		logs := types.LogsToEthereum(res.Logs)
-		var bloomReceipt ethtypes.Bloom
-		if len(logs) > 0 {
-			bloom := k.GetBlockBloomTransient(ctx)
-			bloom.Or(bloom, big.NewInt(0).SetBytes(ethtypes.CreateBloom(&ethtypes.Receipt{Logs: logs}).Bytes()))
-			bloomReceipt = ethtypes.BytesToBloom(bloom.Bytes())
-			k.SetBlockBloomTransient(ctx, bloomReceipt.Big())
-			k.SetLogSizeTransient(ctx, (k.GetLogSizeTransient(ctx))+uint64(len(logs)))
+		if !res.Failed() {
+			txLogAttrs := make([]sdk.Attribute, len(res.Logs))
+			for i, log := range res.Logs {
+				log.TxHash = ethTxHash
+				value, err := json.Marshal(log)
+				if err != nil {
+					return nil, errorsmod.Wrap(err, "failed to encode log")
+				}
+				txLogAttrs[i] = sdk.NewAttribute(types.AttributeKeyTxLog, string(value))
+			}
+
+			ctx.EventManager().EmitEvents(sdk.Events{
+				sdk.NewEvent(
+					types.EventTypeTxLog,
+					txLogAttrs...,
+				),
+			})
+
+			logs := types.LogsToEthereum(res.Logs)
+			var bloomReceipt ethtypes.Bloom
+			if len(logs) > 0 {
+				bloom := k.GetBlockBloomTransient(ctx)
+				bloom.Or(bloom, big.NewInt(0).SetBytes(ethtypes.CreateBloom(&ethtypes.Receipt{Logs: logs}).Bytes()))
+				bloomReceipt = ethtypes.BytesToBloom(bloom.Bytes())
+				k.SetBlockBloomTransient(ctx, bloomReceipt.Big())
+				k.SetLogSizeTransient(ctx, (k.GetLogSizeTransient(ctx))+uint64(len(logs)))
+			}
 		}
+
+		k.SetTxIndexTransient(ctx, uint64(txConfig.TxIndex)+1)
 	}
 
 	if res.Failed() {


### PR DESCRIPTION
…d tx receipts

# Description

# fix(rpc): fall through to CometBFT on KV indexer miss to serve derived tx receipts

## Problem

On the donut testnet, Blockscout was indexing only 15–22% of blocks per day after the `evm-v0-4-0` upgrade, leaving ~80% of blocks silently unindexed.

Push Chain produces two classes of EVM transactions:
- **Native txs** (`MsgEthereumTx`) — signed by a user wallet, stored in the KV indexer
- **Derived txs** (`DerivedEVMCall`) — auto-generated by Cosmos modules (`x/uexecutor`, `x/utss`) for Universal Transactions inbound from Solana, Ethereum, BNB, Arbitrum etc.

Both types are included in the `transactions[]` array returned by `eth_getBlockByNumber`. However, `eth_getTransactionReceipt` returned `null` for derived tx hashes because `kv_indexer.go` only stores native txs — it skips everything that isn't a `MsgEthereumTx`:

```go
// indexer/kv_indexer.go
if !isEthTx(tx) {
    continue  // derived txs are never written to the KV index
}
```

When `GetTxByEthHash` was called with a derived hash, the KV indexer returned "not found" and the function immediately returned an error — never attempting the CometBFT fallback that sits below it and is fully capable of resolving derived txs.

Before `v0.4.0`, the upstream change `8fb90ba2` ("get receipt should not return error on tx not found") had the node returning `(nil, err)` for missing receipts, which the RPC layer surfaced as a JSON-RPC **error response**. Blockscout handled errors gracefully by skipping those hashes. After `8fb90ba2`, the same miss returns `(nil, nil)`, which the RPC layer surfaces as a JSON-RPC **null result**. Blockscout treats null differently — it keeps the hash in its processing pipeline and crashes with a `KeyError` when the receipt is absent from the merge map. The crash discards the entire block, including native txs that had valid receipts.

We confirmed this live on the unpatched testnet: 4 out of 6 sampled transactions were derived txs with null receipts. In 3 out of 5 sampled blocks, every transaction was a derived tx — meaning Blockscout crashed on the whole block and recorded nothing.

## Root Cause

`GetTxByEthHash` short-circuited on a KV miss instead of falling through to the CometBFT indexer:

```go
// Before
if b.Indexer != nil {
    txRes, err := b.Indexer.GetByTxHash(hash)
    if err != nil {
        return nil, nil, err  // gave up here — CometBFT never tried
    }
    return txRes, nil, nil
}
// CometBFT fallback — unreachable for derived txs
```

## Fix

When the KV indexer returns "not found", fall through to the CometBFT query instead of returning immediately:

```go
// After
if b.Indexer != nil {
    txRes, err := b.Indexer.GetByTxHash(hash)
    if err == nil {
        return txRes, nil, nil
    }
    // KV miss — fall through to CometBFT for derived txs
}
// CometBFT fallback — now reached on KV miss
```

The CometBFT path was already capable of handling derived txs. Derived txs emit `ethereum_tx` events with the `ethereumTxHash` attribute when they execute (`x/vm/keeper/call_evm.go`), so `TxSearch` finds them. `ParseTxIndexerResult` detects `DerivedTxType` (99) and returns both a `TxResult` and a populated `TxResultAdditionalFields`. `GetTransactionReceipt` then builds a complete receipt from those additional fields via `parseDerivedTxFromAdditionalFields` — the same path already used by `eth_getBlockByNumber` to surface derived txs in the block view.

The same fix is applied to `GetTxByEthHashAndMsgIndex` which has the identical pattern.

## Impact

- `eth_getTransactionReceipt` now returns a real receipt for derived tx hashes
- Blockscout receives receipts for all hashes in a block — no crash, full block indexed
- Native txs continue to use the fast KV path unchanged; the CometBFT fallback is only hit on a KV miss
- No state migration, no re-indexing, no schema changes — rolling node restart is sufficient

## Testing

- Added `TestGetTxByEthHash_DerivedTxFallthrough` — sets up a KV indexer that always returns "not found", mocks CometBFT to return a derived tx event response, and asserts that `GetTxByEthHash` returns non-nil `TxResultAdditionalFields` with `Type == DerivedTxType`, correct sender and recipient
- Added `TestGetTxByEthHash_NativeTxKVHit` — regression test asserting native txs still return directly from KV without touching CometBFT
- All existing `./rpc/...` tests pass

## Files Changed

- `rpc/backend/tx_info.go` — fallthrough fix in `GetTxByEthHash` and `GetTxByEthHashAndMsgIndex`
- `rpc/backend/tx_info_derived_test.go` — new tests for the fix


---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
