### PR TITLE
[F-2026-17736] : Derived call can commit state even when commit=false

### DIFF
--- a/x/vm/keeper/call_evm.go
+++ b/x/vm/keeper/call_evm.go
@@ -239,13 +239,12 @@ func (k Keeper) DerivedEVMCallWithData(
 	// thus restricted to be used only inside `ApplyMessage`.
 	tmpCtx, commitState := ctx.CacheContext()
 
-	// pass true to commit the StateDB
-	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, true, cfg, txConfig)
+	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, commit, cfg, txConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	if !res.Failed() {
+	if commit && !res.Failed() {
 		commitState()
 	}
 

--- a/x/vm/keeper/call_evm_test.go
+++ b/x/vm/keeper/call_evm_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -9,6 +10,7 @@ import (
 	testconstants "github.com/cosmos/evm/testutil/constants"
 	utiltx "github.com/cosmos/evm/testutil/tx"
 	"github.com/cosmos/evm/x/erc20/types"
+	"github.com/cosmos/evm/x/vm/keeper/testdata"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 )
 
@@ -144,6 +146,76 @@ func (suite *KeeperTestSuite) TestCallEVMWithData() {
 				suite.Require().NoError(err)
 			} else {
 				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
+// TestDerivedEVMCallCommitFlag is a regression test for F-2026-17736: a derived
+// call with commit=false must not persist any state changes, while commit=true
+// must persist them. It deploys an ERC20, performs a state-changing transfer via
+// DerivedEVMCall, and asserts the recipient balance in the underlying store —
+// reading it back with the independent CallEVM read path, since the bug was
+// invisible on the passed context object and only observable at the store level.
+func (suite *KeeperTestSuite) TestDerivedEVMCallCommitFlag() {
+	testCases := []struct {
+		name      string
+		commit    bool
+		expChange bool
+	}{
+		{"commit=false must NOT persist state", false, false},
+		{"commit=true must persist state", true, true},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // reset
+
+			erc20Contract, err := testdata.LoadERC20Contract()
+			suite.Require().NoError(err)
+			erc20ABI := erc20Contract.ABI
+
+			owner := suite.keyring.GetAddr(0)
+			recipient := utiltx.GenerateAddress()
+			amount := big.NewInt(1000)
+
+			contractAddr := suite.DeployTestContract(suite.T(), suite.network.GetContext(), owner, big.NewInt(1_000_000))
+
+			// balanceOf reads through CallEVM (a read-only path independent of the
+			// function under test) so the assertion reflects committed store state.
+			balanceOf := func(addr common.Address) *big.Int {
+				res, err := suite.network.App.EVMKeeper.CallEVM(
+					suite.network.GetContext(), erc20ABI, types.ModuleAddress, contractAddr, false, "balanceOf", addr,
+				)
+				suite.Require().NoError(err)
+				out, err := erc20ABI.Unpack("balanceOf", res.Ret)
+				suite.Require().NoError(err)
+				return out[0].(*big.Int)
+			}
+
+			suite.Require().Equal(int64(0), balanceOf(recipient).Int64(), "recipient must start at zero balance")
+
+			_, err = suite.network.App.EVMKeeper.DerivedEVMCall(
+				suite.network.GetContext(),
+				erc20ABI,
+				owner,         // from
+				contractAddr,  // contract
+				big.NewInt(0), // value
+				nil,           // gasLimit
+				tc.commit,     // commit (flag under test)
+				false,        // gasless
+				false,        // isModuleSender
+				nil,          // manualNonce
+				"transfer",
+				recipient, amount,
+			)
+			suite.Require().NoError(err)
+
+			got := balanceOf(recipient)
+			if tc.expChange {
+				suite.Require().Equal(amount.Int64(), got.Int64(), "commit=true: transfer must be persisted")
+			} else {
+				suite.Require().Equal(int64(0), got.Int64(), "commit=false: state must NOT be persisted")
 			}
 		})
 	}


### PR DESCRIPTION

# [F-2026-17736]  DerivedEVMCallWithData Ignores `commit` Flag

## Issue

`DerivedEVMCallWithData` accepts a `commit bool` parameter but silently ignores it in two places, causing state to always be persisted regardless of what the caller passes.

**File:** `x/vm/keeper/call_evm.go`

### Bug 1 — Hardcoded `true` in `ApplyMessageWithConfig`

```go
// pass true to commit the StateDB
res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, true, cfg, txConfig)
```

The StateDB (which holds EVM balance changes, storage writes, and newly created contracts) is always told to flush its dirty state to the underlying store, regardless of the `commit` parameter.

### Bug 2 — Unconditional `commitState()`

```go
if !res.Failed() {
    commitState()
}
```

The cache context sandbox is always propagated back to the parent context on success, regardless of the `commit` parameter.

### Impact

Any caller passing `commit=false` expects non-mutating, dry-run behavior — simulations, gas estimations, speculative IBC callback checks. Instead, both the StateDB and the cache context are committed, silently mutating chain state. The bug is invisible at the call site because the caller's context object is not directly modified; the mutation happens at the underlying store level.

There is also an internal contradiction: `isFake` on the EVM message is correctly set to `!commit`, so the EVM itself treats the execution as a simulation — but its output is still persisted.

---

## Solution

Two targeted changes in `x/vm/keeper/call_evm.go`:

**1. Pass `commit` into `ApplyMessageWithConfig` instead of hardcoded `true`:**

```go
res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, commit, cfg, txConfig)
```

**2. Gate `commitState()` on the `commit` flag:**

```go
if commit && !res.Failed() {
    commitState()
}
```

### Behavior after fix

| `commit` | Execution succeeds | StateDB flushed | Cache context committed |
|----------|--------------------|-----------------|-------------------------|
| `true`   | yes                | yes             | yes                     |
| `true`   | no                 | yes             | no                      |
| `false`  | yes                | no              | no                      |
| `false`  | no                 | no              | no                      |

When `commit=false`, execution still runs and the result is returned to the caller, but zero state changes escape to the underlying store. True dry-run semantics are restored.



Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
