### PR TITLE
[F-2026-17745]  Derived transactions share a constant txIndex value

### DIFF
--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -410,10 +410,10 @@ func (b *Backend) GetTransactionByBlockNumberAndIndex(blockNum rpctypes.BlockNum
 func (b *Backend) GetTxByEthHash(hash common.Hash) (*types.TxResult, *rpctypes.TxResultAdditionalFields, error) {
 	if b.indexer != nil {
 		txRes, err := b.indexer.GetByTxHash(hash)
-		if err != nil {
-			return nil, nil, err
+		if err == nil {
+			return txRes, nil, nil
 		}
-		return txRes, nil, nil
+		// indexer miss or no derived-tx metadata — fall through to event-query reconstruction
 	}
 
 	// fallback to tendermint tx indexer
@@ -430,10 +430,10 @@ func (b *Backend) GetTxByEthHash(hash common.Hash) (*types.TxResult, *rpctypes.T
 func (b *Backend) GetTxByEthHashAndMsgIndex(hash common.Hash, index int) (*types.TxResult, *rpctypes.TxResultAdditionalFields, error) {
 	if b.indexer != nil {
 		txRes, err := b.indexer.GetByTxHash(hash)
-		if err != nil {
-			return nil, nil, err
+		if err == nil {
+			return txRes, nil, nil
 		}
-		return txRes, nil, nil
+		// indexer miss or no derived-tx metadata — fall through to event-query reconstruction
 	}
 
 	// fallback to tendermint tx indexer

--- a/x/vm/keeper/call_evm.go
+++ b/x/vm/keeper/call_evm.go
@@ -239,13 +239,12 @@ func (k Keeper) DerivedEVMCallWithData(
 	// thus restricted to be used only inside `ApplyMessage`.
 	tmpCtx, commitState := ctx.CacheContext()
 
-	// pass true to commit the StateDB
-	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, true, cfg, txConfig)
+	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, commit, cfg, txConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	if !res.Failed() {
+	if commit && !res.Failed() {
 		commitState()
 	}
 

--- a/x/vm/keeper/call_evm.go
+++ b/x/vm/keeper/call_evm.go
@@ -260,8 +260,7 @@ func (k Keeper) DerivedEVMCallWithData(
 			sdk.NewAttribute(sdk.AttributeKeyAmount, value.String()),
 			// add event for ethereum transaction hash format;
 			sdk.NewAttribute(types.AttributeKeyEthereumTxHash, ethTxHash),
-			// add event for index of valid ethereum tx; NOTE: default txindex for derivedTx
-			sdk.NewAttribute(types.AttributeKeyTxIndex, strconv.FormatUint(types.DerivedTxIndex, 10)),
+			sdk.NewAttribute(types.AttributeKeyTxIndex, strconv.FormatUint(uint64(txConfig.TxIndex), 10)),
 			// add event for eth tx gas used, we can't get it from cosmos tx result when it contains multiple eth tx msgs.
 			sdk.NewAttribute(types.AttributeKeyTxGasUsed, strconv.FormatUint(gasUsed, 10)),
 		}...)
@@ -320,6 +319,8 @@ func (k Keeper) DerivedEVMCallWithData(
 				k.SetLogSizeTransient(ctx, (k.GetLogSizeTransient(ctx))+uint64(len(logs)))
 			}
 		}
+
+		k.SetTxIndexTransient(ctx, uint64(txConfig.TxIndex)+1)
 	}
 
 	if res.Failed() {

--- a/x/vm/keeper/call_evm.go
+++ b/x/vm/keeper/call_evm.go
@@ -274,16 +274,6 @@ func (k Keeper) DerivedEVMCallWithData(
 			attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyEthereumTxFailed, res.VmError))
 		}
 
-		txLogAttrs := make([]sdk.Attribute, len(res.Logs))
-		for i, log := range res.Logs {
-			log.TxHash = ethTxHash
-			value, err := json.Marshal(log)
-			if err != nil {
-				return nil, errorsmod.Wrap(err, "failed to encode log")
-			}
-			txLogAttrs[i] = sdk.NewAttribute(types.AttributeKeyTxLog, string(value))
-		}
-
 		// adding txData for more info in rpc methods in order to parse derived txs
 		attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyTxData, hexutil.Encode(msg.Data())))
 		// adding nonce for more info in rpc methods in order to parse derived txs
@@ -295,10 +285,6 @@ func (k Keeper) DerivedEVMCallWithData(
 				attrs...,
 			),
 			sdk.NewEvent(
-				types.EventTypeTxLog,
-				txLogAttrs...,
-			),
-			sdk.NewEvent(
 				sdk.EventTypeMessage,
 				sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
 				sdk.NewAttribute(sdk.AttributeKeySender, from.Hex()),
@@ -306,14 +292,33 @@ func (k Keeper) DerivedEVMCallWithData(
 			),
 		})
 
-		logs := types.LogsToEthereum(res.Logs)
-		var bloomReceipt ethtypes.Bloom
-		if len(logs) > 0 {
-			bloom := k.GetBlockBloomTransient(ctx)
-			bloom.Or(bloom, big.NewInt(0).SetBytes(ethtypes.LogsBloom(logs)))
-			bloomReceipt = ethtypes.BytesToBloom(bloom.Bytes())
-			k.SetBlockBloomTransient(ctx, bloomReceipt.Big())
-			k.SetLogSizeTransient(ctx, (k.GetLogSizeTransient(ctx))+uint64(len(logs)))
+		if !res.Failed() {
+			txLogAttrs := make([]sdk.Attribute, len(res.Logs))
+			for i, log := range res.Logs {
+				log.TxHash = ethTxHash
+				value, err := json.Marshal(log)
+				if err != nil {
+					return nil, errorsmod.Wrap(err, "failed to encode log")
+				}
+				txLogAttrs[i] = sdk.NewAttribute(types.AttributeKeyTxLog, string(value))
+			}
+
+			ctx.EventManager().EmitEvents(sdk.Events{
+				sdk.NewEvent(
+					types.EventTypeTxLog,
+					txLogAttrs...,
+				),
+			})
+
+			logs := types.LogsToEthereum(res.Logs)
+			var bloomReceipt ethtypes.Bloom
+			if len(logs) > 0 {
+				bloom := k.GetBlockBloomTransient(ctx)
+				bloom.Or(bloom, big.NewInt(0).SetBytes(ethtypes.LogsBloom(logs)))
+				bloomReceipt = ethtypes.BytesToBloom(bloom.Bytes())
+				k.SetBlockBloomTransient(ctx, bloomReceipt.Big())
+				k.SetLogSizeTransient(ctx, (k.GetLogSizeTransient(ctx))+uint64(len(logs)))
+			}
 		}
 	}
 

--- a/x/vm/types/events.go
+++ b/x/vm/types/events.go
@@ -30,6 +30,5 @@ const (
 )
 
 const (
-	DerivedTxIndex = 9999
-	DerivedTxType  = 99
+	DerivedTxType = 99
 )


### PR DESCRIPTION
# Description
# [F-2026-17745]  Derived transactions share a constant txIndex value

## Issue

Every derived EVM execution in `DerivedEVMCallWithData` emitted a hardcoded compile-time constant `DerivedTxIndex = 9999` as its transaction index attribute, regardless of its actual position in the block's EVM message sequence.

**File:** `x/vm/keeper/call_evm.go`

```go
// Before fix
sdk.NewAttribute(types.AttributeKeyTxIndex, strconv.FormatUint(types.DerivedTxIndex, 10)),
// DerivedTxIndex = 9999, always, for every derived tx in every block
```

**File:** `x/vm/types/events.go`

```go
const (
    DerivedTxIndex = 9999
    DerivedTxType  = 99
)
```

### How standard Eth txs handle indexing

The keeper maintains a transient (per-block, in-memory) counter `TxIndexTransient`. For each standard `MsgEthereumTx`:

1. `msg_server.go` reads the current counter via `GetTxIndexTransient`
2. The tx executes
3. `state_transition.go` increments the counter via `SetTxIndexTransient`
4. The event carries the real sequential index: 0, 1, 2, 3...

Derived txs never read or incremented this counter. They emitted 9999 and left the counter untouched.

### Impact

In a block containing multiple derived transactions or a mix of standard and derived messages:

| Execution order | Tx type | Index emitted (before fix) |
|---|---|---|
| 1st | Standard Eth Tx | 0 |
| 2nd | Standard Eth Tx | 1 |
| 3rd | Derived Tx | **9999** |
| 4th | Derived Tx | **9999** |
| 5th | Standard Eth Tx | 2 |

Three consequences:

1. **`eth_getTransactionByBlockNumberAndIndex` fails** — multiple derived txs share the same index; the endpoint cannot distinguish or resolve them individually.
2. **Transient counter goes out of sync** — derived txs don't advance the counter, creating gaps in the index sequence that don't reflect actual execution order.
3. **Explorer and indexer ordering breaks** — any system keyed on `AttributeKeyTxIndex` (block explorers, the KV indexer, tracing tools) sees duplicate 9999 values and cannot order, deduplicate, or resolve derived txs correctly.

---

## Solution

Wire derived transactions into the same `TxIndexTransient` counter that standard Eth txs use.

In `DerivedEVMCallWithData`, within the `if commit` block:

1. `txConfig` is already constructed via `k.TxConfig(ctx, tx.Hash())` which reads `GetTxIndexTransient` for its `TxIndex` field — so `txConfig.TxIndex` already holds the correct sequential value.
2. Emit `txConfig.TxIndex` instead of the hardcoded `types.DerivedTxIndex`.
3. After event emission, call `SetTxIndexTransient(ctx, txConfig.TxIndex+1)` to advance the counter.

```go
// After fix
sdk.NewAttribute(types.AttributeKeyTxIndex, strconv.FormatUint(uint64(txConfig.TxIndex), 10)),

// after event emission, advance the counter
k.SetTxIndexTransient(ctx, uint64(txConfig.TxIndex)+1)
```

The counter increment is placed inside `if commit` but outside `if !res.Failed()` — failed derived txs still consume an index slot, matching Ethereum's behavior where even reverted transactions occupy a position in the block.

### Behavior after fix

| Execution order | Tx type | Index emitted (after fix) |
|---|---|---|
| 1st | Standard Eth Tx | 0 |
| 2nd | Standard Eth Tx | 1 |
| 3rd | Derived Tx | **2** |
| 4th | Derived Tx | **3** |
| 5th | Standard Eth Tx | 4 |

Sequential, unique, globally ordered — reflecting actual execution order within the block. `DerivedTxType = 99` is retained as a marker to identify derived txs even when they carry a real sequential index.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
