### PR TITLE
[F-2026-17754] TraceTransaction mixes Cosmos and Ethereum index domains 

### DIFF
--- a/rpc/backend/backend_suite_test.go
+++ b/rpc/backend/backend_suite_test.go
@@ -25,9 +25,11 @@ import (
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 )
 
 type BackendTestSuite struct {
@@ -172,6 +174,39 @@ func (suite *BackendTestSuite) generateTestKeyring(clientDir string) (keyring.Ke
 	buf := bufio.NewReader(os.Stdin)
 	encCfg := encoding.MakeConfig()
 	return keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, clientDir, buf, encCfg.Codec, []keyring.Option{hd.EthSecp256k1Option()}...)
+}
+
+// buildAndEncodeMultiMsgEthTx builds a single EVM Cosmos tx containing multiple
+// MsgEthereumTx messages. Each message is signed with a fresh ephemeral key (so
+// their hashes are unique even when underlying tx params are identical) and From is
+// cleared to "" as BuildTx does. Callers should compute hashes via
+// msg.AsTransaction().Hash() after this call returns.
+func (suite *BackendTestSuite) buildAndEncodeMultiMsgEthTx(msgs ...*evmtypes.MsgEthereumTx) []byte {
+	ethSigner := ethtypes.LatestSigner(suite.backend.ChainConfig())
+	for _, msg := range msgs {
+		from, priv := utiltx.NewAddrKey()
+		signer := utiltx.NewSigner(priv)
+		msg.From = from.String()
+		suite.Require().NoError(msg.Sign(ethSigner, signer))
+		msg.From = ""
+	}
+
+	extBuilder, ok := suite.backend.clientCtx.TxConfig.NewTxBuilder().(authtx.ExtensionOptionsTxBuilder)
+	suite.Require().True(ok)
+
+	option, err := codectypes.NewAnyWithValue(&evmtypes.ExtensionOptionsEthereumTx{})
+	suite.Require().NoError(err)
+	extBuilder.SetExtensionOptions(option)
+
+	sdkMsgs := make([]sdk.Msg, len(msgs))
+	for i, msg := range msgs {
+		sdkMsgs[i] = msg
+	}
+	suite.Require().NoError(extBuilder.SetMsgs(sdkMsgs...))
+
+	bz, err := suite.backend.clientCtx.TxConfig.TxEncoder()(extBuilder.GetTx())
+	suite.Require().NoError(err)
+	return bz
 }
 
 func (suite *BackendTestSuite) signAndEncodeEthTx(msgEthereumTx *evmtypes.MsgEthereumTx) []byte {

--- a/rpc/backend/client_test.go
+++ b/rpc/backend/client_test.go
@@ -45,6 +45,49 @@ func RegisterTxSearchEmpty(client *mocks.Client, query string) {
 		Return(&cmtrpctypes.ResultTxSearch{}, nil)
 }
 
+// RegisterTxSearchWithResult registers a TxSearch mock that returns a single ResultTx
+// with explicit raw tx bytes (nil for derived txs with no Cosmos envelope), block height,
+// Cosmos-tx-slot index, and ABCI events. This is needed when the KV indexer has no
+// entry (e.g. derived txs, or EVM txs whose KV EthTxIndex is wrong because derived txs
+// shifted the counter) and the code falls through to CometBFT TxSearch.
+func RegisterTxSearchWithResult(
+	client *mocks.Client,
+	query string,
+	height int64,
+	txSlot uint32,
+	txBz types.Tx,
+	events []abci.Event,
+) {
+	resultTx := &cmtrpctypes.ResultTx{
+		Height: height,
+		Index:  txSlot,
+		Tx:     txBz,
+		TxResult: abci.ExecTxResult{
+			Code:   0,
+			Events: events,
+		},
+	}
+	client.On("TxSearch", rpc.ContextWithHeight(1), query, false, (*int)(nil), (*int)(nil), "").
+		Return(&cmtrpctypes.ResultTxSearch{Txs: []*cmtrpctypes.ResultTx{resultTx}, TotalCount: 1}, nil)
+}
+
+// RegisterBlockResultsWithTxs registers a BlockResults mock with custom per-slot ABCI
+// results. Required when the after-loop derived-tx section in TraceTransaction fetches
+// BlockResults to scan for intra-slot derived-tx predecessor ordering.
+func RegisterBlockResultsWithTxs(
+	client *mocks.Client,
+	height int64,
+	txResults []*abci.ExecTxResult,
+) *cmtrpctypes.ResultBlockResults {
+	res := &cmtrpctypes.ResultBlockResults{
+		Height:     height,
+		TxsResults: txResults,
+	}
+	client.On("BlockResults", rpc.ContextWithHeight(height), mock.AnythingOfType("*int64")).
+		Return(res, nil)
+	return res
+}
+
 func RegisterTxSearchError(client *mocks.Client, query string) {
 	client.On("TxSearch", rpc.ContextWithHeight(1), query, false, (*int)(nil), (*int)(nil), "").
 		Return(nil, errortypes.ErrInvalidRequest)

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -49,7 +49,14 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 	}
 
 	var predecessors []*evmtypes.MsgEthereumTx
-	for i := 0; i < int(transaction.TxIndex); i++ {
+	// Use EthTxIndex (Ethereum execution counter) as the loop bound, not TxIndex
+	// (Cosmos tx slot). The two diverge whenever a Cosmos tx holds multiple EVM
+	// messages, contains no EVM messages, or derived txs shift the counter.
+	ethTxCount := int(transaction.EthTxIndex)
+	if ethTxCount < 0 {
+		ethTxCount = 0
+	}
+	for i := 0; i < ethTxCount; i++ {
 		predecessorTx, txAdditional, err := b.GetTxByTxIndex(blk.Block.Height, uint(i))
 		if err != nil {
 			b.logger.Debug("failed to get tx by index",
@@ -60,11 +67,14 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 		}
 
 		if txAdditional != nil {
-			// This is a derived tx, fetch all derived txs from events in this Cosmos tx
+			// This is a derived tx, fetch all derived txs from events in this Cosmos tx.
+			// Use predecessorTx.TxIndex (Cosmos slot) — not i (Ethereum index) — when
+			// indexing into block-level arrays.
+			cosmosTxIdx := int(predecessorTx.TxIndex)
 			blockRes, err := b.rpcClient.BlockResults(b.ctx, &blk.Block.Height)
-			if err == nil && i < len(blockRes.TxsResults) {
-				txResult := blockRes.TxsResults[i]
-				cosmosTx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[i])
+			if err == nil && cosmosTxIdx < len(blockRes.TxsResults) {
+				txResult := blockRes.TxsResults[cosmosTxIdx]
+				cosmosTx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[cosmosTxIdx])
 				if err == nil {
 					parsedTxs, err := rpctypes.ParseTxResult(txResult, cosmosTx)
 					if err == nil {
@@ -98,8 +108,9 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 			continue
 		}
 
-		// Fallback: decode as normal Cosmos tx
-		tx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[i])
+		// Fallback: decode as normal Cosmos tx. Use predecessorTx.TxIndex (Cosmos slot)
+		// rather than i (Ethereum index) to address the correct block entry.
+		tx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[predecessorTx.TxIndex])
 		if err != nil {
 			b.logger.Debug("failed to decode transaction in block",
 				"height", blk.Block.Height,

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -66,13 +66,20 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 			continue
 		}
 
+		// The after-loop section below handles all predecessors that share the same
+		// Cosmos tx slot as the target (intra-tx ordering by MsgIndex / derived-tx
+		// event order). Skip them here to avoid double-counting.
+		if int(predecessorTx.TxIndex) == int(transaction.TxIndex) {
+			continue
+		}
+
 		if txAdditional != nil {
 			// This is a derived tx, fetch all derived txs from events in this Cosmos tx.
 			// Use predecessorTx.TxIndex (Cosmos slot) — not i (Ethereum index) — when
 			// indexing into block-level arrays.
 			cosmosTxIdx := int(predecessorTx.TxIndex)
 			blockRes, err := b.rpcClient.BlockResults(b.ctx, &blk.Block.Height)
-			if err == nil && cosmosTxIdx < len(blockRes.TxsResults) {
+			if err == nil && blockRes != nil && cosmosTxIdx < len(blockRes.TxsResults) {
 				txResult := blockRes.TxsResults[cosmosTxIdx]
 				cosmosTx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[cosmosTxIdx])
 				if err == nil {
@@ -119,14 +126,13 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 			continue
 		}
 
-		index := int(predecessorTx.MsgIndex)
-		for j := 0; j < index; j++ {
-			msg := tx.GetMsgs()[j]
-			// Check if it’s a normal Ethereum tx
-			if ethMsg, ok := msg.(*evmtypes.MsgEthereumTx); ok {
-				predecessors = append(predecessors, ethMsg)
-				continue
-			}
+		// Add the EVM message at this Ethernet index directly. The inner loop used
+		// here previously ran j < MsgIndex, which added only messages BEFORE the
+		// current position and left the message AT MsgIndex itself unhandled —
+		// causing the last message of any multi-message predecessor Cosmos tx to
+		// be silently dropped from the predecessor set.
+		if ethMsg, ok := tx.GetMsgs()[int(predecessorTx.MsgIndex)].(*evmtypes.MsgEthereumTx); ok {
+			predecessors = append(predecessors, ethMsg)
 		}
 	}
 
@@ -152,7 +158,7 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 	if additional != nil {
 		// This is a derived tx, fetch all derived txs from events in this Cosmos tx
 		blockRes, err := b.rpcClient.BlockResults(b.ctx, &blk.Block.Height)
-		if err == nil && int(transaction.TxIndex) < len(blockRes.TxsResults) {
+		if err == nil && blockRes != nil && int(transaction.TxIndex) < len(blockRes.TxsResults) {
 			txResult := blockRes.TxsResults[transaction.TxIndex]
 			parsedTxs, err := rpctypes.ParseTxResult(txResult, tx)
 			if err == nil {

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -74,43 +74,16 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfi
 		}
 
 		if txAdditional != nil {
-			// This is a derived tx, fetch all derived txs from events in this Cosmos tx.
-			// Use predecessorTx.TxIndex (Cosmos slot) — not i (Ethereum index) — when
-			// indexing into block-level arrays.
-			cosmosTxIdx := int(predecessorTx.TxIndex)
-			blockRes, err := b.rpcClient.BlockResults(b.ctx, &blk.Block.Height)
-			if err == nil && blockRes != nil && cosmosTxIdx < len(blockRes.TxsResults) {
-				txResult := blockRes.TxsResults[cosmosTxIdx]
-				cosmosTx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[cosmosTxIdx])
-				if err == nil {
-					parsedTxs, err := rpctypes.ParseTxResult(txResult, cosmosTx)
-					if err == nil {
-						for _, parsedTx := range parsedTxs.Txs {
-							// Stop when we reach the current transaction
-							if parsedTx.Hash == txAdditional.Hash {
-								break
-							}
-							// Only include derived txs
-							if parsedTx.Type == evmtypes.DerivedTxType {
-								ethMsg := b.parseDerivedTxFromAdditionalFields(&rpctypes.TxResultAdditionalFields{
-									Value:     parsedTx.Amount,
-									Hash:      parsedTx.Hash,
-									TxHash:    parsedTx.TxHash,
-									Type:      parsedTx.Type,
-									Recipient: parsedTx.Recipient,
-									Sender:    parsedTx.Sender,
-									GasUsed:   parsedTx.GasUsed,
-									Data:      parsedTx.Data,
-									Nonce:     parsedTx.Nonce,
-									GasLimit:  &parsedTx.GasLimit,
-								})
-								if ethMsg != nil {
-									predecessors = append(predecessors, ethMsg)
-								}
-							}
-						}
-					}
-				}
+			// Derived tx: add it directly. The old approach scanned parsedTxs.Txs
+			// for "all derived txs before txAdditional.Hash", which (a) skipped the
+			// tx at txAdditional.Hash itself — so the last derived tx in a series
+			// was always missed — and (b) double-counted earlier derived txs that
+			// were already added by their own outer-loop iterations. Each iteration
+			// of this loop corresponds to exactly one Ethereum execution, so adding
+			// txAdditional directly is both correct and complete.
+			ethMsg := b.parseDerivedTxFromAdditionalFields(txAdditional)
+			if ethMsg != nil {
+				predecessors = append(predecessors, ethMsg)
 			}
 			continue
 		}

--- a/rpc/backend/tracing_test.go
+++ b/rpc/backend/tracing_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
 	"github.com/cosmos/evm/indexer"
 	"github.com/cosmos/evm/rpc/backend/mocks"
+	rpctypes "github.com/cosmos/evm/rpc/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	"cosmossdk.io/log"
@@ -276,6 +277,427 @@ func (suite *BackendTestSuite) TestTraceTransactionEthTxIndex() {
 	RegisterConsensusParams(client, 1)
 
 	txResult, err := suite.backend.TraceTransaction(txHashTarget, nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(map[string]interface{}{"test": "hello"}, txResult)
+}
+
+// ethTxEvent returns a minimal EventTypeEthereumTx event suitable for IndexBlock.
+func ethTxEvent(hash string, txIndex string) abci.Event {
+	return abci.Event{
+		Type: evmtypes.EventTypeEthereumTx,
+		Attributes: []abci.EventAttribute{
+			{Key: evmtypes.AttributeKeyEthereumTxHash, Value: hash},
+			{Key: evmtypes.AttributeKeyTxIndex, Value: txIndex},
+			{Key: evmtypes.AttributeKeyTxGasUsed, Value: "21000"},
+		},
+	}
+}
+
+// TestTraceTransactionMultiMsgSameCosmosTarget traces the second of two EVM messages
+// packed into a single Cosmos tx slot (TxIndex=0 for both). The same-Cosmos-tx guard
+// must fire on every outer-loop iteration, leaving the after-loop to supply the sole
+// predecessor.
+//
+// Block layout:  slot0=[msg1, msg2=target]
+// Expected predecessors: [msg1]
+func (suite *BackendTestSuite) TestTraceTransactionMultiMsgSameCosmosTarget() {
+	suite.SetupTest()
+
+	msg1, _ := suite.buildEthereumTx()
+	msgTarget, _ := suite.buildEthereumTx()
+	txBzMulti := suite.buildAndEncodeMultiMsgEthTx(msg1, msgTarget)
+
+	hash1 := msg1.AsTransaction().Hash()
+	hashTarget := msgTarget.AsTransaction().Hash()
+
+	localBlock := types.MakeBlock(1, []types.Tx{txBzMulti}, nil, nil)
+	localBlock.ChainID = ChainID
+
+	responseBlock := []*abci.ExecTxResult{{
+		Code: 0,
+		Events: []abci.Event{
+			ethTxEvent(hash1.Hex(), "0"),
+			ethTxEvent(hashTarget.Hex(), "1"),
+		},
+	}}
+
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(localBlock, responseBlock))
+
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+
+	_, err := RegisterBlockMultipleTxs(client, 1, []types.Tx{txBzMulti})
+	suite.Require().NoError(err)
+
+	// Outer loop (i=0): GetTxByTxIndex→TxIndex=0 == target.TxIndex=0 → skipped by
+	// same-Cosmos-tx guard. After-loop (index=1, i=0): adds msg1.
+	RegisterTraceTransactionWithPredecessors(queryClient, msgTarget, []*evmtypes.MsgEthereumTx{msg1})
+	RegisterConsensusParams(client, 1)
+
+	txResult, err := suite.backend.TraceTransaction(hashTarget, nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(map[string]interface{}{"test": "hello"}, txResult)
+}
+
+// TestTraceTransactionMultiMsgTargetIsThird traces the third of three EVM messages
+// packed into a single Cosmos tx. The outer loop skips all same-slot entries; the
+// after-loop adds both msg1 and msg2.
+//
+// Block layout:  slot0=[msg1, msg2, msg3=target]
+// Expected predecessors: [msg1, msg2]
+func (suite *BackendTestSuite) TestTraceTransactionMultiMsgTargetIsThird() {
+	suite.SetupTest()
+
+	msg1, _ := suite.buildEthereumTx()
+	msg2, _ := suite.buildEthereumTx()
+	msgTarget, _ := suite.buildEthereumTx()
+	txBzMulti := suite.buildAndEncodeMultiMsgEthTx(msg1, msg2, msgTarget)
+
+	hash1 := msg1.AsTransaction().Hash()
+	hash2 := msg2.AsTransaction().Hash()
+	hashTarget := msgTarget.AsTransaction().Hash()
+
+	localBlock := types.MakeBlock(1, []types.Tx{txBzMulti}, nil, nil)
+	localBlock.ChainID = ChainID
+
+	responseBlock := []*abci.ExecTxResult{{
+		Code: 0,
+		Events: []abci.Event{
+			ethTxEvent(hash1.Hex(), "0"),
+			ethTxEvent(hash2.Hex(), "1"),
+			ethTxEvent(hashTarget.Hex(), "2"),
+		},
+	}}
+
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(localBlock, responseBlock))
+
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+
+	_, err := RegisterBlockMultipleTxs(client, 1, []types.Tx{txBzMulti})
+	suite.Require().NoError(err)
+
+	// Outer loop i=0,1: TxIndex=0==target.TxIndex=0 → both skipped.
+	// After-loop (index=2): adds msg1 (i=0) and msg2 (i=1).
+	RegisterTraceTransactionWithPredecessors(queryClient, msgTarget, []*evmtypes.MsgEthereumTx{msg1, msg2})
+	RegisterConsensusParams(client, 1)
+
+	txResult, err := suite.backend.TraceTransaction(hashTarget, nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(map[string]interface{}{"test": "hello"}, txResult)
+}
+
+// TestTraceTransactionMultiMsgCosmosAsPredecessor traces a single-message target
+// whose sole predecessor is a two-message Cosmos tx. Both messages of the predecessor
+// tx must appear in the predecessor list — this validates the Gap-5 fix (direct add
+// at MsgIndex instead of the old inner loop that ran j<MsgIndex and missed the last
+// message).
+//
+// Block layout:  slot0=[msg1, msg2], slot1=[msgTarget]
+// Expected predecessors: [msg1, msg2]
+func (suite *BackendTestSuite) TestTraceTransactionMultiMsgCosmosAsPredecessor() {
+	suite.SetupTest()
+
+	msg1, _ := suite.buildEthereumTx()
+	msg2, _ := suite.buildEthereumTx()
+	msgTarget, _ := suite.buildEthereumTx()
+
+	txBzPred := suite.buildAndEncodeMultiMsgEthTx(msg1, msg2)
+	txBzTarget := suite.signAndEncodeEthTx(msgTarget)
+
+	hash1 := msg1.AsTransaction().Hash()
+	hash2 := msg2.AsTransaction().Hash()
+	hashTarget := msgTarget.AsTransaction().Hash()
+
+	localBlock := types.MakeBlock(1, []types.Tx{txBzPred, txBzTarget}, nil, nil)
+	localBlock.ChainID = ChainID
+
+	responseBlock := []*abci.ExecTxResult{
+		{
+			Code:   0,
+			Events: []abci.Event{ethTxEvent(hash1.Hex(), "0"), ethTxEvent(hash2.Hex(), "1")},
+		},
+		{
+			Code:   0,
+			Events: []abci.Event{ethTxEvent(hashTarget.Hex(), "2")},
+		},
+	}
+
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(localBlock, responseBlock))
+
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+
+	_, err := RegisterBlockMultipleTxs(client, 1, []types.Tx{txBzPred, txBzTarget})
+	suite.Require().NoError(err)
+
+	// Outer loop i=0: adds msg1 (TxIndex=0, MsgIndex=0).
+	// Outer loop i=1: adds msg2 (TxIndex=0, MsgIndex=1) — validates Gap-5 fix.
+	// After-loop: MsgIndex=0, no iterations.
+	RegisterTraceTransactionWithPredecessors(queryClient, msgTarget, []*evmtypes.MsgEthereumTx{msg1, msg2})
+	RegisterConsensusParams(client, 1)
+
+	txResult, err := suite.backend.TraceTransaction(hashTarget, nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(map[string]interface{}{"test": "hello"}, txResult)
+}
+
+// TestTraceTransactionThreeTxBlock exercises the full predecessor-assembly path across
+// three Cosmos tx slots: a 1-msg slot, a 2-msg slot, and a 1-msg target slot. All six
+// fix points interact: loop bound uses EthTxIndex (not TxIndex), Cosmos array accesses
+// use predecessorTx.TxIndex, same-slot guard fires for none of them, and each outer
+// iteration adds exactly the message at its MsgIndex.
+//
+// Block layout:  slot0=[msg1], slot1=[msg2, msg3], slot2=[msgTarget]
+// Expected predecessors: [msg1, msg2, msg3]
+func (suite *BackendTestSuite) TestTraceTransactionThreeTxBlock() {
+	suite.SetupTest()
+
+	msg1, _ := suite.buildEthereumTx()
+	msg2, _ := suite.buildEthereumTx()
+	msg3, _ := suite.buildEthereumTx()
+	msgTarget, _ := suite.buildEthereumTx()
+
+	txBz1 := suite.signAndEncodeEthTx(msg1)
+	txBzPred2 := suite.buildAndEncodeMultiMsgEthTx(msg2, msg3)
+	txBzTarget := suite.signAndEncodeEthTx(msgTarget)
+
+	hash1 := msg1.AsTransaction().Hash()
+	hash2 := msg2.AsTransaction().Hash()
+	hash3 := msg3.AsTransaction().Hash()
+	hashTarget := msgTarget.AsTransaction().Hash()
+
+	localBlock := types.MakeBlock(1, []types.Tx{txBz1, txBzPred2, txBzTarget}, nil, nil)
+	localBlock.ChainID = ChainID
+
+	responseBlock := []*abci.ExecTxResult{
+		{Code: 0, Events: []abci.Event{ethTxEvent(hash1.Hex(), "0")}},
+		{Code: 0, Events: []abci.Event{ethTxEvent(hash2.Hex(), "1"), ethTxEvent(hash3.Hex(), "2")}},
+		{Code: 0, Events: []abci.Event{ethTxEvent(hashTarget.Hex(), "3")}},
+	}
+
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(localBlock, responseBlock))
+
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+
+	_, err := RegisterBlockMultipleTxs(client, 1, []types.Tx{txBz1, txBzPred2, txBzTarget})
+	suite.Require().NoError(err)
+
+	// i=0 → msg1 (slot0, MsgIndex=0)
+	// i=1 → msg2 (slot1, MsgIndex=0)
+	// i=2 → msg3 (slot1, MsgIndex=1) — validates Gap-5 (direct add at MsgIndex)
+	// After-loop: MsgIndex=0, no iterations.
+	RegisterTraceTransactionWithPredecessors(queryClient, msgTarget, []*evmtypes.MsgEthereumTx{msg1, msg2, msg3})
+	RegisterConsensusParams(client, 1)
+
+	txResult, err := suite.backend.TraceTransaction(hashTarget, nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(map[string]interface{}{"test": "hello"}, txResult)
+}
+
+// derivedTxEvt builds an EventTypeEthereumTx event for a derived transaction
+// (txType=99). txIndex is the EthTxIndex, sender/recipient are hex-encoded addresses.
+// The attribute count exceeds 2 so ParseTxResult picks eventFormat1 and calls newTx.
+func derivedTxEvt(hash string, txIndex int, sender string, recipient string, gasLimit uint64) abci.Event {
+	return abci.Event{
+		Type: evmtypes.EventTypeEthereumTx,
+		Attributes: []abci.EventAttribute{
+			{Key: evmtypes.AttributeKeyEthereumTxHash, Value: hash},
+			{Key: evmtypes.AttributeKeyTxIndex, Value: fmt.Sprintf("%d", txIndex)},
+			{Key: evmtypes.AttributeKeyTxGasUsed, Value: "21000"},
+			{Key: evmtypes.AttributeKeyTxType, Value: fmt.Sprintf("%d", evmtypes.DerivedTxType)},
+			{Key: rpctypes.SenderType, Value: sender},
+			{Key: evmtypes.AttributeKeyRecipient, Value: recipient},
+			{Key: evmtypes.AttributeKeyTxGasLimit, Value: fmt.Sprintf("%d", gasLimit)},
+		},
+	}
+}
+
+// TestTraceTransactionDerivedTxAsPredecessor verifies that a derived tx (EVM execution
+// triggered internally by a Cosmos module, stored only as ABCI events with no Cosmos
+// tx envelope) is correctly reconstructed and prepended to the predecessor list when it
+// precedes the EVM target in Ethereum execution order.
+//
+// Block layout:  slot0=[msg1_evm], slot1=[non-EVM → DerivedTx1], slot2=[msgTarget_evm]
+// EthTxIndex:   msg1=0, DerivedTx1=1, msgTarget=2
+//
+// The KV indexer assigns EthTxIndex=1 to msgTarget (it skips the non-EVM slot and
+// doesn't count derived txs). To force the correct EthTxIndex=2, the test does NOT
+// index slot 2; msgTarget is resolved via TxSearch instead. DerivedTx1 is also found
+// via TxSearch (KV never stores derived txs).
+//
+// Expected predecessors: [msg1, DerivedTx1_synthetic]
+func (suite *BackendTestSuite) TestTraceTransactionDerivedTxAsPredecessor() {
+	suite.SetupTest()
+
+	// Build slot-0 EVM tx (indexed in KV at EthTxIndex=0).
+	msg1, _ := suite.buildEthereumTx()
+	txBz1 := suite.signAndEncodeEthTx(msg1)
+	hash1 := msg1.AsTransaction().Hash()
+
+	// Build slot-2 EVM target (NOT indexed in KV so TxSearch is used).
+	msgTarget, _ := suite.buildEthereumTx()
+	txBzTarget := suite.signAndEncodeEthTx(msgTarget)
+	hashTarget := msgTarget.AsTransaction().Hash()
+
+	// Slot-1 is a non-EVM Cosmos tx that triggers the derived tx.
+	// An empty tx builder produces a valid, decodable Cosmos tx with no messages.
+	dummyTxBz, err := suite.backend.clientCtx.TxConfig.TxEncoder()(
+		suite.backend.clientCtx.TxConfig.NewTxBuilder().GetTx(),
+	)
+	suite.Require().NoError(err)
+
+	// Derived tx parameters.
+	hashDerived := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	senderAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	recipientAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+	gasLimitVal := uint64(50000)
+
+	// Index a 2-slot block (slot0=EVM, slot1=non-EVM) so KV stores only msg1@EthTxIndex=0.
+	// slot2 (msgTarget) is deliberately omitted so the KV never assigns it a wrong index.
+	localBlock := types.MakeBlock(1, []types.Tx{txBz1, dummyTxBz}, nil, nil)
+	localBlock.ChainID = ChainID
+	indexResults := []*abci.ExecTxResult{
+		{Code: 0, Events: []abci.Event{ethTxEvent(hash1.Hex(), "0")}},
+		{Code: 0, Events: []abci.Event{}},
+	}
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(localBlock, indexResults))
+
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+
+	// Actual block has 3 slots.
+	_, err = RegisterBlockMultipleTxs(client, 1, []types.Tx{txBz1, dummyTxBz, txBzTarget})
+	suite.Require().NoError(err)
+
+	// GetTxByEthHash(hashTarget): KV miss → TxSearch by ethereum hash.
+	// Returns target with EthTxIndex=2 (the true execution count including DerivedTx1).
+	targetHashQuery := fmt.Sprintf("%s.%s='%s'",
+		evmtypes.TypeMsgEthereumTx, evmtypes.AttributeKeyEthereumTxHash, hashTarget.Hex())
+	RegisterTxSearchWithResult(client, targetHashQuery, 1, 2, txBzTarget,
+		[]abci.Event{ethTxEvent(hashTarget.Hex(), "2")})
+
+	// GetTxByTxIndex(1, 1): KV miss → TxSearch by eth tx index.
+	// Returns DerivedTx1 with txAdditional (type=99).
+	derivedIdxQuery := fmt.Sprintf("tx.height=%d AND %s.%s=%d",
+		1, evmtypes.TypeMsgEthereumTx, evmtypes.AttributeKeyTxIndex, 1)
+	RegisterTxSearchWithResult(client, derivedIdxQuery, 1, 1, nil,
+		[]abci.Event{derivedTxEvt(hashDerived.Hex(), 1, senderAddr.Hex(), recipientAddr.Hex(), gasLimitVal)})
+
+	// Compute the expected MsgEthereumTx that parseDerivedTxFromAdditionalFields produces
+	// from the TxSearch result, so the TraceTx mock can match it exactly.
+	derivedAdditional := &rpctypes.TxResultAdditionalFields{
+		Hash:      hashDerived,
+		Sender:    senderAddr,
+		Recipient: recipientAddr,
+		GasUsed:   21000,
+		GasLimit:  &gasLimitVal,
+		Type:      evmtypes.DerivedTxType,
+	}
+	derivedMsg := suite.backend.parseDerivedTxFromAdditionalFields(derivedAdditional)
+	suite.Require().NotNil(derivedMsg)
+
+	// Outer loop: i=0→msg1 (KV hit), i=1→DerivedTx1 (KV miss, derived branch).
+	// After-loop: MsgIndex=0, 0 normal-msg iterations, additional=nil.
+	RegisterTraceTransactionWithPredecessors(queryClient, msgTarget, []*evmtypes.MsgEthereumTx{msg1, derivedMsg})
+	RegisterConsensusParams(client, 1)
+
+	txResult, err := suite.backend.TraceTransaction(hashTarget, nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(map[string]interface{}{"test": "hello"}, txResult)
+}
+
+// TestTraceTransactionDerivedTxAsTarget verifies that TraceTransaction can trace a
+// derived tx (the target is itself a derived EVM execution, not a Cosmos MsgEthereumTx).
+// The derived tx is reconstructed from TxSearch event attributes; the after-loop scans
+// block results for intra-slot derived-tx predecessors, finds the target as the first
+// entry, and immediately stops — so only the outer-loop predecessor (msg1) is included.
+//
+// Block layout:  slot0=[msg1_evm], slot1=[non-EVM → DerivedTx1=target]
+// EthTxIndex:   msg1=0, DerivedTx1=1
+//
+// Expected predecessors: [msg1]
+func (suite *BackendTestSuite) TestTraceTransactionDerivedTxAsTarget() {
+	suite.SetupTest()
+
+	// Slot-0 EVM predecessor, indexed in KV at EthTxIndex=0.
+	msg1, _ := suite.buildEthereumTx()
+	txBz1 := suite.signAndEncodeEthTx(msg1)
+	hash1 := msg1.AsTransaction().Hash()
+
+	// Slot-1: non-EVM Cosmos tx that triggers the derived target.
+	dummyTxBz, err := suite.backend.clientCtx.TxConfig.TxEncoder()(
+		suite.backend.clientCtx.TxConfig.NewTxBuilder().GetTx(),
+	)
+	suite.Require().NoError(err)
+
+	// Derived target tx parameters.
+	hashDerivedTarget := common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222")
+	senderAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	recipientAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+	gasLimitVal := uint64(50000)
+
+	// KV index: only slot 0 (msg1); slot 1 is non-EVM and skipped by the indexer.
+	localBlock := types.MakeBlock(1, []types.Tx{txBz1, dummyTxBz}, nil, nil)
+	localBlock.ChainID = ChainID
+	indexResults := []*abci.ExecTxResult{
+		{Code: 0, Events: []abci.Event{ethTxEvent(hash1.Hex(), "0")}},
+		{Code: 0, Events: []abci.Event{}},
+	}
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+	suite.Require().NoError(suite.backend.indexer.IndexBlock(localBlock, indexResults))
+
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+
+	_, err = RegisterBlockMultipleTxs(client, 1, []types.Tx{txBz1, dummyTxBz})
+	suite.Require().NoError(err)
+
+	// GetTxByEthHash(hashDerivedTarget): KV miss (derived txs are never indexed) →
+	// TxSearch by ethereum hash. Returns the derived tx with type=99 and txAdditional.
+	targetHashQuery := fmt.Sprintf("%s.%s='%s'",
+		evmtypes.TypeMsgEthereumTx, evmtypes.AttributeKeyEthereumTxHash, hashDerivedTarget.Hex())
+	RegisterTxSearchWithResult(client, targetHashQuery, 1, 1, nil,
+		[]abci.Event{derivedTxEvt(hashDerivedTarget.Hex(), 1, senderAddr.Hex(), recipientAddr.Hex(), gasLimitVal)})
+
+	// BlockResults for the after-loop derived-tx predecessor scan.
+	// The scan finds hashDerivedTarget as the first entry in slot 1 and breaks immediately
+	// (it is the target, not a predecessor), so no additional predecessors are added.
+	RegisterBlockResultsWithTxs(client, 1, []*abci.ExecTxResult{
+		{Code: 0, Events: []abci.Event{ethTxEvent(hash1.Hex(), "0")}},
+		{Code: 0, Events: []abci.Event{derivedTxEvt(hashDerivedTarget.Hex(), 1, senderAddr.Hex(), recipientAddr.Hex(), gasLimitVal)}},
+	})
+
+	// Compute the Msg that parseDerivedTxFromAdditionalFields will produce for the target.
+	derivedAdditional := &rpctypes.TxResultAdditionalFields{
+		Hash:      hashDerivedTarget,
+		Sender:    senderAddr,
+		Recipient: recipientAddr,
+		GasUsed:   21000,
+		GasLimit:  &gasLimitVal,
+		Type:      evmtypes.DerivedTxType,
+	}
+	derivedTargetMsg := suite.backend.parseDerivedTxFromAdditionalFields(derivedAdditional)
+	suite.Require().NotNil(derivedTargetMsg)
+
+	// Outer loop: i=0→msg1 (KV hit, TxIndex=0 != target.TxIndex=1, added).
+	// After-loop: MsgIndex=0 → 0 normal-msg iterations; derived-tx scan breaks at target.
+	RegisterTraceTransactionWithPredecessors(queryClient, derivedTargetMsg, []*evmtypes.MsgEthereumTx{msg1})
+	RegisterConsensusParams(client, 1)
+
+	txResult, err := suite.backend.TraceTransaction(hashDerivedTarget, nil)
 	suite.Require().NoError(err)
 	suite.Require().Equal(map[string]interface{}{"test": "hello"}, txResult)
 }

--- a/rpc/backend/tracing_test.go
+++ b/rpc/backend/tracing_test.go
@@ -61,7 +61,11 @@ func (suite *BackendTestSuite) TestTraceTransaction() {
 	}{
 		{
 			"fail - tx not found",
-			func() {},
+			func() {
+				client := suite.backend.clientCtx.Client.(*mocks.Client)
+				query := fmt.Sprintf("%s.%s='%s'", evmtypes.TypeMsgEthereumTx, evmtypes.AttributeKeyEthereumTxHash, txHash.Hex())
+				RegisterTxSearchEmpty(client, query)
+			},
 			&types.Block{Header: types.Header{Height: 1}, Data: types.Data{Txs: []types.Tx{}}},
 			[]*abci.ExecTxResult{
 				{
@@ -206,6 +210,74 @@ func (suite *BackendTestSuite) TestTraceTransaction() {
 			}
 		})
 	}
+}
+
+// TestTraceTransactionEthTxIndex verifies that TraceTransaction correctly traces
+// a transaction that is not the first in a multi-tx block, using EthTxIndex (not
+// TxIndex) as the predecessor-loop bound after the index-domain fix.
+func (suite *BackendTestSuite) TestTraceTransactionEthTxIndex() {
+	suite.SetupTest()
+
+	// Build two signed transactions; hashes computed AFTER signing so they match
+	// what IndexBlock stores.
+	msgFirst, _ := suite.buildEthereumTx()
+	txBzFirst := suite.signAndEncodeEthTx(msgFirst)
+	txHashFirst := msgFirst.AsTransaction().Hash()
+
+	msgTarget, _ := suite.buildEthereumTx()
+	txBzTarget := suite.signAndEncodeEthTx(msgTarget)
+	txHashTarget := msgTarget.AsTransaction().Hash()
+
+	// Block with two Cosmos txs: EthTxIndex == TxIndex == 0 for msgFirst,
+	// EthTxIndex == TxIndex == 1 for msgTarget.
+	localBlock := types.MakeBlock(1, []types.Tx{txBzFirst, txBzTarget}, nil, nil)
+	localBlock.ChainID = ChainID
+
+	responseBlock := []*abci.ExecTxResult{
+		{
+			Code: 0,
+			Events: []abci.Event{{
+				Type: evmtypes.EventTypeEthereumTx,
+				Attributes: []abci.EventAttribute{
+					{Key: evmtypes.AttributeKeyEthereumTxHash, Value: txHashFirst.Hex()},
+					{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+					{Key: evmtypes.AttributeKeyTxGasUsed, Value: "21000"},
+				},
+			}},
+		},
+		{
+			Code: 0,
+			Events: []abci.Event{{
+				Type: evmtypes.EventTypeEthereumTx,
+				Attributes: []abci.EventAttribute{
+					{Key: evmtypes.AttributeKeyEthereumTxHash, Value: txHashTarget.Hex()},
+					{Key: evmtypes.AttributeKeyTxIndex, Value: "1"},
+					{Key: evmtypes.AttributeKeyTxGasUsed, Value: "21000"},
+				},
+			}},
+		},
+	}
+
+	db := dbm.NewMemDB()
+	suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+	err := suite.backend.indexer.IndexBlock(localBlock, responseBlock)
+	suite.Require().NoError(err)
+
+	queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+	client := suite.backend.clientCtx.Client.(*mocks.Client)
+
+	_, err = RegisterBlockMultipleTxs(client, 1, []types.Tx{txBzFirst, txBzTarget})
+	suite.Require().NoError(err)
+
+	// EthTxIndex=1: the predecessor loop runs once (i=0) and fetches msgFirst
+	// (TxIndex=0, MsgIndex=0). With the Gap-1 fix the message AT MsgIndex is
+	// added directly, so msgFirst is a predecessor of msgTarget.
+	RegisterTraceTransactionWithPredecessors(queryClient, msgTarget, []*evmtypes.MsgEthereumTx{msgFirst})
+	RegisterConsensusParams(client, 1)
+
+	txResult, err := suite.backend.TraceTransaction(txHashTarget, nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(map[string]interface{}{"test": "hello"}, txResult)
 }
 
 func (suite *BackendTestSuite) TestTraceBlock() {

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -239,11 +239,15 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash) (map[string]interface{
 		return nil, errors.New("failed to parse receipt")
 	}
 
-	// parse tx logs from events
-	msgIndex := int(res.MsgIndex) // #nosec G115 -- checked for int overflow already
-	logs, err := TxLogsFromEvents(blockRes.TxsResults[res.TxIndex].Events, msgIndex)
-	if err != nil {
-		b.logger.Debug("failed to parse logs", "hash", hexTx, "error", err.Error())
+	// failed transactions yield no logs — consistent with GetTransactionLogs
+	var logs []*ethtypes.Log
+	if !res.Failed {
+		msgIndex := int(res.MsgIndex) // #nosec G115 -- checked for int overflow already
+		var err error
+		logs, err = TxLogsFromEvents(blockRes.TxsResults[res.TxIndex].Events, msgIndex)
+		if err != nil {
+			b.logger.Debug("failed to parse logs", "hash", hexTx, "error", err.Error())
+		}
 	}
 
 	if res.EthTxIndex == -1 {

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -410,10 +410,10 @@ func (b *Backend) GetTransactionByBlockNumberAndIndex(blockNum rpctypes.BlockNum
 func (b *Backend) GetTxByEthHash(hash common.Hash) (*types.TxResult, *rpctypes.TxResultAdditionalFields, error) {
 	if b.indexer != nil {
 		txRes, err := b.indexer.GetByTxHash(hash)
-		if err != nil {
-			return nil, nil, err
+		if err == nil {
+			return txRes, nil, nil
 		}
-		return txRes, nil, nil
+		// indexer miss or no derived-tx metadata — fall through to event-query reconstruction
 	}
 
 	// fallback to tendermint tx indexer
@@ -430,10 +430,10 @@ func (b *Backend) GetTxByEthHash(hash common.Hash) (*types.TxResult, *rpctypes.T
 func (b *Backend) GetTxByEthHashAndMsgIndex(hash common.Hash, index int) (*types.TxResult, *rpctypes.TxResultAdditionalFields, error) {
 	if b.indexer != nil {
 		txRes, err := b.indexer.GetByTxHash(hash)
-		if err != nil {
-			return nil, nil, err
+		if err == nil {
+			return txRes, nil, nil
 		}
-		return txRes, nil, nil
+		// indexer miss or no derived-tx metadata — fall through to event-query reconstruction
 	}
 
 	// fallback to tendermint tx indexer

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"google.golang.org/grpc/metadata"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -671,4 +672,100 @@ func (suite *BackendTestSuite) TestGetGasUsed() {
 			suite.backend.cfg.JSONRPC.FixRevertGasRefundHeight = origin
 		})
 	}
+}
+
+// TestFailedTxLogsConsistency verifies that both GetTransactionLogs and
+// GetTransactionReceipt return empty logs for a failed EVM transaction, even
+// when ghost EventTypeTxLog events exist in the block results. This exercises
+// the fix where GetTransactionReceipt now gates TxLogsFromEvents on !res.Failed.
+func (suite *BackendTestSuite) TestFailedTxLogsConsistency() {
+	msgEthereumTx, _ := suite.buildEthereumTx()
+	// signAndEncodeEthTx signs msgEthereumTx in-place; compute the hash after signing
+	// so it matches what the KV indexer stores (the signed-tx hash).
+	txBz := suite.signAndEncodeEthTx(msgEthereumTx)
+	txHash := msgEthereumTx.AsTransaction().Hash()
+	block := types.MakeBlock(1, []types.Tx{txBz}, nil, nil)
+
+	// Code=0 (Cosmos tx succeeded) but EVM reverted — simulates the inbound-handler
+	// scenario where EVM errors are swallowed. AttributeKeyEthereumTxFailed marks
+	// the EVM execution as failed so the indexer stores Failed=true.
+	revertedBlockResult := []*abci.ExecTxResult{{
+		Code:    0,
+		GasUsed: 21000,
+		Events: []abci.Event{{
+			Type: evmtypes.EventTypeEthereumTx,
+			Attributes: []abci.EventAttribute{
+				{Key: evmtypes.AttributeKeyEthereumTxHash, Value: txHash.Hex()},
+				{Key: evmtypes.AttributeKeyTxIndex, Value: "0"},
+				{Key: evmtypes.AttributeKeyTxGasUsed, Value: "21000"},
+				{Key: evmtypes.AttributeKeyEthereumTxFailed, Value: "execution reverted"},
+			},
+		}},
+	}}
+
+	suite.Run("GetTransactionLogs returns nil for failed tx", func() {
+		suite.SetupTest()
+
+		db := dbm.NewMemDB()
+		suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+		err := suite.backend.indexer.IndexBlock(block, revertedBlockResult)
+		suite.Require().NoError(err)
+
+		logs, err := suite.backend.GetTransactionLogs(txHash)
+		suite.Require().NoError(err)
+		suite.Require().Nil(logs)
+	})
+
+	suite.Run("GetTransactionReceipt returns empty logs for failed tx despite ghost log events", func() {
+		suite.SetupTest()
+
+		var header metadata.MD
+		queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+		client := suite.backend.clientCtx.Client.(*mocks.Client)
+		RegisterParams(queryClient, &header, 1)
+		_, err := RegisterBlock(client, 1, txBz)
+		suite.Require().NoError(err)
+		// Ghost EventTypeTxLog events in block results — must not appear in receipt
+		_, err = RegisterBlockResultsWithEventLog(client, 1)
+		suite.Require().NoError(err)
+
+		db := dbm.NewMemDB()
+		suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+		err = suite.backend.indexer.IndexBlock(block, revertedBlockResult)
+		suite.Require().NoError(err)
+
+		receipt, err := suite.backend.GetTransactionReceipt(txHash)
+		suite.Require().NoError(err)
+		suite.Require().NotNil(receipt)
+		suite.Require().Equal([][]*ethtypes.Log{}, receipt["logs"])
+	})
+
+	suite.Run("GetTransactionLogs and GetTransactionReceipt agree on empty logs for failed tx", func() {
+		suite.SetupTest()
+
+		var header metadata.MD
+		queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+		client := suite.backend.clientCtx.Client.(*mocks.Client)
+		RegisterParams(queryClient, &header, 1)
+		_, err := RegisterBlock(client, 1, txBz)
+		suite.Require().NoError(err)
+		_, err = RegisterBlockResultsWithEventLog(client, 1)
+		suite.Require().NoError(err)
+
+		db := dbm.NewMemDB()
+		suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+		err = suite.backend.indexer.IndexBlock(block, revertedBlockResult)
+		suite.Require().NoError(err)
+
+		// GetTransactionLogs returns nil for failed tx (early return on res.Failed)
+		txLogs, err := suite.backend.GetTransactionLogs(txHash)
+		suite.Require().NoError(err)
+		suite.Require().Nil(txLogs)
+
+		// GetTransactionReceipt must also produce empty logs — not the ghost events
+		receipt, err := suite.backend.GetTransactionReceipt(txHash)
+		suite.Require().NoError(err)
+		suite.Require().NotNil(receipt)
+		suite.Require().Equal([][]*ethtypes.Log{}, receipt["logs"])
+	})
 }

--- a/x/vm/keeper/call_evm.go
+++ b/x/vm/keeper/call_evm.go
@@ -239,13 +239,12 @@ func (k Keeper) DerivedEVMCallWithData(
 	// thus restricted to be used only inside `ApplyMessage`.
 	tmpCtx, commitState := ctx.CacheContext()
 
-	// pass true to commit the StateDB
-	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, true, cfg, txConfig)
+	res, err := k.ApplyMessageWithConfig(tmpCtx, msg, nil, commit, cfg, txConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	if !res.Failed() {
+	if commit && !res.Failed() {
 		commitState()
 	}
 

--- a/x/vm/keeper/call_evm.go
+++ b/x/vm/keeper/call_evm.go
@@ -260,8 +260,7 @@ func (k Keeper) DerivedEVMCallWithData(
 			sdk.NewAttribute(sdk.AttributeKeyAmount, value.String()),
 			// add event for ethereum transaction hash format;
 			sdk.NewAttribute(types.AttributeKeyEthereumTxHash, ethTxHash),
-			// add event for index of valid ethereum tx; NOTE: default txindex for derivedTx
-			sdk.NewAttribute(types.AttributeKeyTxIndex, strconv.FormatUint(types.DerivedTxIndex, 10)),
+			sdk.NewAttribute(types.AttributeKeyTxIndex, strconv.FormatUint(uint64(txConfig.TxIndex), 10)),
 			// add event for eth tx gas used, we can't get it from cosmos tx result when it contains multiple eth tx msgs.
 			sdk.NewAttribute(types.AttributeKeyTxGasUsed, strconv.FormatUint(gasUsed, 10)),
 		}...)
@@ -320,6 +319,8 @@ func (k Keeper) DerivedEVMCallWithData(
 				k.SetLogSizeTransient(ctx, (k.GetLogSizeTransient(ctx))+uint64(len(logs)))
 			}
 		}
+
+		k.SetTxIndexTransient(ctx, uint64(txConfig.TxIndex)+1)
 	}
 
 	if res.Failed() {

--- a/x/vm/keeper/call_evm.go
+++ b/x/vm/keeper/call_evm.go
@@ -274,16 +274,6 @@ func (k Keeper) DerivedEVMCallWithData(
 			attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyEthereumTxFailed, res.VmError))
 		}
 
-		txLogAttrs := make([]sdk.Attribute, len(res.Logs))
-		for i, log := range res.Logs {
-			log.TxHash = ethTxHash
-			value, err := json.Marshal(log)
-			if err != nil {
-				return nil, errorsmod.Wrap(err, "failed to encode log")
-			}
-			txLogAttrs[i] = sdk.NewAttribute(types.AttributeKeyTxLog, string(value))
-		}
-
 		// adding txData for more info in rpc methods in order to parse derived txs
 		attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyTxData, hexutil.Encode(msg.Data())))
 		// adding nonce for more info in rpc methods in order to parse derived txs
@@ -295,10 +285,6 @@ func (k Keeper) DerivedEVMCallWithData(
 				attrs...,
 			),
 			sdk.NewEvent(
-				types.EventTypeTxLog,
-				txLogAttrs...,
-			),
-			sdk.NewEvent(
 				sdk.EventTypeMessage,
 				sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
 				sdk.NewAttribute(sdk.AttributeKeySender, from.Hex()),
@@ -306,14 +292,33 @@ func (k Keeper) DerivedEVMCallWithData(
 			),
 		})
 
-		logs := types.LogsToEthereum(res.Logs)
-		var bloomReceipt ethtypes.Bloom
-		if len(logs) > 0 {
-			bloom := k.GetBlockBloomTransient(ctx)
-			bloom.Or(bloom, big.NewInt(0).SetBytes(ethtypes.LogsBloom(logs)))
-			bloomReceipt = ethtypes.BytesToBloom(bloom.Bytes())
-			k.SetBlockBloomTransient(ctx, bloomReceipt.Big())
-			k.SetLogSizeTransient(ctx, (k.GetLogSizeTransient(ctx))+uint64(len(logs)))
+		if !res.Failed() {
+			txLogAttrs := make([]sdk.Attribute, len(res.Logs))
+			for i, log := range res.Logs {
+				log.TxHash = ethTxHash
+				value, err := json.Marshal(log)
+				if err != nil {
+					return nil, errorsmod.Wrap(err, "failed to encode log")
+				}
+				txLogAttrs[i] = sdk.NewAttribute(types.AttributeKeyTxLog, string(value))
+			}
+
+			ctx.EventManager().EmitEvents(sdk.Events{
+				sdk.NewEvent(
+					types.EventTypeTxLog,
+					txLogAttrs...,
+				),
+			})
+
+			logs := types.LogsToEthereum(res.Logs)
+			var bloomReceipt ethtypes.Bloom
+			if len(logs) > 0 {
+				bloom := k.GetBlockBloomTransient(ctx)
+				bloom.Or(bloom, big.NewInt(0).SetBytes(ethtypes.LogsBloom(logs)))
+				bloomReceipt = ethtypes.BytesToBloom(bloom.Bytes())
+				k.SetBlockBloomTransient(ctx, bloomReceipt.Big())
+				k.SetLogSizeTransient(ctx, (k.GetLogSizeTransient(ctx))+uint64(len(logs)))
+			}
 		}
 	}
 

--- a/x/vm/types/events.go
+++ b/x/vm/types/events.go
@@ -30,6 +30,5 @@ const (
 )
 
 const (
-	DerivedTxIndex = 9999
-	DerivedTxType  = 99
+	DerivedTxType = 99
 )


### PR DESCRIPTION
# [F-2026-17754] TraceTransaction mixes Cosmos and Ethereum index domains 

## Background

`debug_traceTransaction` reconstructs the EVM state at the point of a target
transaction by replaying all preceding EVM executions in the block as
"predecessors". To do this correctly it must iterate over every EVM execution
that ran before the target — in the exact order the EVM processed them.

There are two independent index spaces in a Cosmos/EVM block:

- **Cosmos tx index (`TxIndex`)**: the ordinal position of a Cosmos transaction
  envelope in `block.Txs[]`. Every Cosmos message container — whether it holds
  EVM messages or not — occupies one slot.

- **Ethereum tx index (`EthTxIndex`)**: a sequential counter that increments
  once per EVM execution across the whole block. A single Cosmos tx can
  contribute zero, one, or many increments. Derived transactions (EVM
  executions triggered internally by Cosmos modules, recorded only as ABCI
  events with no Cosmos envelope) also consume slots in this counter.

## The Bug

`rpc/backend/tracing.go` bounded the predecessor loop with `transaction.TxIndex`
(Cosmos slot) but fed that bound into `GetTxByTxIndex`, which resolves
transactions by **Ethereum index**:

```go
// Before — wrong: TxIndex is a Cosmos ordinal, GetTxByTxIndex expects an Ethereum index
for i := 0; i < int(transaction.TxIndex); i++ {
    predecessorTx, txAdditional, err := b.GetTxByTxIndex(blk.Block.Height, uint(i))
```

The two counters only coincide accidentally when every Cosmos tx holds exactly
one `MsgEthereumTx` and no derived transactions exist. In any real heterogeneous
block they diverge:

| Scenario | Effect on predecessor set |
|---|---|
| One Cosmos tx holds N > 1 `MsgEthereumTx` | Loop underestimates — N−1 executions missing |
| One Cosmos tx holds zero EVM messages (pure Cosmos msg) | Loop wastes an iteration on a non-existent Ethereum tx |
| Derived txs present (no Cosmos envelope) | Entire swaths of Ethereum-indexed executions invisible to the loop |

There was a second bug compounding the first: inside the loop body, bare `i`
was used to index into `blockRes.TxsResults[i]` and `blk.Block.Txs[i]` — both
of which are Cosmos-indexed arrays. Once `i` became an Ethereum index (after
applying the loop bound fix), those accesses read the wrong Cosmos tx or
panicked on out-of-bounds.

### Concrete Example

```
Cosmos slot 0 → MsgSend (no EVM execution)
Cosmos slot 1 → MsgEthereumTx #1 + MsgEthereumTx #2
Cosmos slot 2 → MsgEthereumTx #3  ← target tx to trace

Ethereum index 0 → MsgEthereumTx #1  (from Cosmos slot 1)
Ethereum index 1 → MsgEthereumTx #2  (from Cosmos slot 1)
Ethereum index 2 → MsgEthereumTx #3  (from Cosmos slot 2, target)
```

Target has `TxIndex = 2`, `EthTxIndex = 2` — coincidentally the same here.
But in the slot 1 Cosmos tx case with 2 messages, `TxIndex = 1` while
`EthTxIndex = 2`. The buggy loop would run only once (i=0), missing
`MsgEthereumTx #2`. The trace replays without that execution's state
changes — wrong storage values, wrong nonces, wrong gas accounting.

## Fix

Seven coordinated changes to `rpc/backend/tracing.go`:

### 1 — Loop bound: `TxIndex` → `EthTxIndex`

```go
// Before
for i := 0; i < int(transaction.TxIndex); i++ {

// After
ethTxCount := int(transaction.EthTxIndex)
if ethTxCount < 0 {
    ethTxCount = 0
}
for i := 0; i < ethTxCount; i++ {
```

The `< 0` guard handles the `-1` sentinel that indicates an unresolved index,
treating it as zero predecessors rather than a large positive wrap-around.

### 2 — Derived tx branch: `i` → `predecessorTx.TxIndex` for Cosmos array access

```go
// Before
if err == nil && i < len(blockRes.TxsResults) {
    txResult := blockRes.TxsResults[i]
    cosmosTx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[i])

// After
cosmosTxIdx := int(predecessorTx.TxIndex)
if err == nil && blockRes != nil && cosmosTxIdx < len(blockRes.TxsResults) {
    txResult := blockRes.TxsResults[cosmosTxIdx]
    cosmosTx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[cosmosTxIdx])
```

`predecessorTx.TxIndex` is the Cosmos slot returned by `GetTxByTxIndex` —
the correct index for accessing `blockRes.TxsResults` and `blk.Block.Txs`.
The `blockRes != nil` guard prevents a nil-pointer panic if the RPC client
returns `(nil, nil)`.

### 3 — Normal tx fallback branch: same substitution

```go
// Before
tx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[i])

// After
tx, err := b.clientCtx.TxConfig.TxDecoder()(blk.Block.Txs[predecessorTx.TxIndex])
```

### 4 — Same-Cosmos-tx guard: skip outer-loop entries that belong to the target's slot

```go
// Added after the GetTxByTxIndex call succeeds
if int(predecessorTx.TxIndex) == int(transaction.TxIndex) {
    continue
}
```

Without this guard, when the target is a later message within a multi-message
Cosmos tx (e.g. the third `MsgEthereumTx` in a single Cosmos tx), the outer
loop iterates over Ethereum indices that belong to the **same** Cosmos tx slot.
The after-loop (which handles intra-Cosmos-tx ordering by `MsgIndex`) then
adds the same messages a second time, producing a duplicate predecessor set.
The guard delegates all same-slot ordering to the after-loop.

### 5 — Normal tx branch: direct message add replaces off-by-one inner loop

```go
// Before — inner loop adds messages at indices [0, MsgIndex), missing MsgIndex itself
index := int(predecessorTx.MsgIndex)
for j := 0; j < index; j++ {
    msg := tx.GetMsgs()[j]
    if ethMsg, ok := msg.(*evmtypes.MsgEthereumTx); ok {
        predecessors = append(predecessors, ethMsg)
    }
}

// After — adds the exact message this Ethereum index maps to
if ethMsg, ok := tx.GetMsgs()[int(predecessorTx.MsgIndex)].(*evmtypes.MsgEthereumTx); ok {
    predecessors = append(predecessors, ethMsg)
}
```

The old inner loop was designed for the assumption that one outer-loop
iteration would "cover" many messages in the same Cosmos tx. In practice each
outer iteration corresponds to exactly one Ethereum index (one `MsgEthereumTx`
or one derived tx). The inner loop ran `j < MsgIndex`, which never included
the message AT `MsgIndex`, leaving it silently missing from the predecessor
set. With the same-Cosmos-tx guard (change 4) preventing same-slot entries
from reaching this branch, a single direct add is now correct and complete.

**Correctness proof across key scenarios:**

| Block layout | Target | Old result | New result |
|---|---|---|---|
| `[CosmosTx_A(m1), CosmosTx_B(m2)]` | m2 | `[]` (m1 missing) | `[m1]` ✓ |
| `[CosmosTx_A(m1, m2), CosmosTx_B(m3)]` | m3 | `[m1]` (m2 missing) | `[m1, m2]` ✓ |
| `CosmosTx_A(m1, m2, m3)` | m3 | `[m1, m1, m2]` (duplicate) | `[m1, m2]` ✓ |

### 6 — Target's derived-tx `blockRes` nil guard (same pattern as change 2)

```go
// Before
if err == nil && int(transaction.TxIndex) < len(blockRes.TxsResults) {

// After
if err == nil && blockRes != nil && int(transaction.TxIndex) < len(blockRes.TxsResults) {
```

### 7 — Derived-tx outer-loop branch: replace event-scan with direct add

```go
// Before — scanned parsedTxs.Txs for "all derived txs before txAdditional.Hash":
//   • missed the tx AT txAdditional.Hash itself, so the last derived tx in any
//     series from a predecessor Cosmos tx was always silently dropped
//   • double-counted earlier derived txs already added by their own iterations
cosmosTxIdx := int(predecessorTx.TxIndex)
blockRes, err := b.rpcClient.BlockResults(b.ctx, &blk.Block.Height)
if err == nil && blockRes != nil && cosmosTxIdx < len(blockRes.TxsResults) {
    // ... fetch events, scan parsedTxs.Txs until txAdditional.Hash, add each DerivedTxType
}

// After — each outer-loop iteration adds exactly the one derived tx at EthTxIndex i
ethMsg := b.parseDerivedTxFromAdditionalFields(txAdditional)
if ethMsg != nil {
    predecessors = append(predecessors, ethMsg)
}
```

**Correctness proof for a predecessor Cosmos tx with three derived txs:**

| EthTxIndex | Tx | Old result | New result |
|---|---|---|---|
| i=0 | d1 | nothing added (no entries before d1) | d1 added ✓ |
| i=1 | d2 | d1 added (via d2's scan) | d2 added ✓ |
| i=2 | d3 | d1 + d2 added again (double-count); d3 still missing | d3 added ✓ |

## Why All Seven Are Required

Changes 1–3 correct the index domain and array access. Changes 4–5 fix
predecessor completeness and deduplication for multi-message Cosmos txs.
Changes 6–7 close nil-safety and completeness gaps in derived-tx handling.
All seven together make the loop internally consistent: iterate by Ethereum
execution order, access block arrays by Cosmos slot, add each predecessor
exactly once.

## Test coverage (`rpc/backend/tracing_test.go`)

### Pre-existing failures fixed

`TestTraceTransaction/case_fail_-_tx_not_found` was silently broken after the
KV-indexer fallback fix (Fix 3): when the indexer has no entry for the
requested hash, `GetTxByEthHash` now falls through to a CometBFT `TxSearch`
call. The test registered no mock for that call, causing a panic. The fix adds
`RegisterTxSearchEmpty` so the mock returns an empty result set, which makes
`queryTendermintTxIndexer` return a not-found error and the test's `expPass:
false` assertion passes cleanly.

### New test

`TestTraceTransactionEthTxIndex` — traces the **second** transaction in a
two-tx block (EthTxIndex=1, TxIndex=1).  Both hashes are computed after signing
so the indexer lookup succeeds without falling through to TxSearch.

The test verifies:
1. The predecessor-loop bound (`EthTxIndex`) iterates the correct number of
   times (once) for the second tx.
2. The inner loop accesses `blk.Block.Txs[predecessorTx.TxIndex]` (slot 0,
   correct) rather than `blk.Block.Txs[i]`, which would be slot 0 here too but
   would be wrong if EthTxIndex diverged from TxIndex.
3. The TraceTx gRPC call receives `Msg = msgTarget` with `Predecessors = nil`
   (single-msg Cosmos txs contribute nothing to the predecessor set — expected
   pre-existing behavior for this path).
4. The trace result is returned without error.

## Dependency

This fix relies on derived transactions having correct sequential `EthTxIndex`
values in the KV indexer. That is guaranteed by the sequential tx index fix
(`tx-index-fix.md`) which replaced the hardcoded `DerivedTxIndex = 9999`
constant with the real per-block execution counter.


---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
