### PR TITLE
[F-2026-17740][Re-eval]  KV indexer path misses derived transactions

### DIFF
--- a/indexer/kv_indexer.go
+++ b/indexer/kv_indexer.go
@@ -25,6 +25,10 @@ import (
 const (
 	KeyPrefixTxHash  = 1
 	KeyPrefixTxIndex = 2
+	// KeyPrefixTxDerived marks a tx hash as a derived EVM tx (event-only, no embedded
+	// MsgEthereumTx). Lets the RPC backend cheaply decide whether a KV-indexer hit needs
+	// its TxResultAdditionalFields rebuilt from events, without parsing every lookup.
+	KeyPrefixTxDerived = 3
 
 	// TxIndexKeyLength is the length of tx-index key
 	TxIndexKeyLength = 1 + 8 + 8
@@ -70,6 +74,15 @@ func (kv *KVIndexer) IndexBlock(block *cmttypes.Block, txResults []*abci.ExecTxR
 		}
 
 		if !isEthTx(tx) {
+			// Derived txs (internal EVM executions emitted only as events, not as an
+			// embedded MsgEthereumTx) still occupy slots in the block's eth-tx index
+			// sequence. Index them by hash and by (height, ethTxIndex), advancing
+			// the shared ethTxIndex so it stays aligned with the emitted txIndex for any
+			// standard eth txs that follow in the same block.
+			ethTxIndex, err = kv.indexDerivedTxs(batch, height, uint32(txIndex), result, ethTxIndex) //#nosec G115
+			if err != nil {
+				kv.logger.Error("Fail to index derived txs", "err", err, "block", height, "txIndex", txIndex)
+			}
 			continue
 		}
 
@@ -161,9 +174,98 @@ func (kv *KVIndexer) GetByBlockAndIndex(blockNumber int64, txIndex int32) (*serv
 	return kv.GetByTxHash(common.BytesToHash(bz))
 }
 
+// IsDerivedTx reports whether the hash was indexed as a derived EVM tx (event-only, no
+// embedded MsgEthereumTx). A cheap single key read used by the RPC backend to gate the
+// (more expensive) rebuild of TxResultAdditionalFields from block events.
+func (kv *KVIndexer) IsDerivedTx(hash common.Hash) (bool, error) {
+	bz, err := kv.db.Get(DerivedTxHashKey(hash))
+	if err != nil {
+		return false, errorsmod.Wrapf(err, "IsDerivedTx %s", hash.Hex())
+	}
+	return len(bz) > 0, nil
+}
+
+// IsDerivedTxByBlockAndIndex reports whether the tx at (blockNumber, eth tx index) is a
+// derived EVM tx. It resolves the hash from the block-index entry and consults the derived
+// marker — two cheap key reads — so the RPC backend can gate derived-tx reconstruction on
+// the block-index path without reparsing block events for ordinary txs.
+func (kv *KVIndexer) IsDerivedTxByBlockAndIndex(blockNumber int64, txIndex int32) (bool, error) {
+	bz, err := kv.db.Get(TxIndexKey(blockNumber, txIndex))
+	if err != nil {
+		return false, errorsmod.Wrapf(err, "IsDerivedTxByBlockAndIndex %d %d", blockNumber, txIndex)
+	}
+	if len(bz) == 0 {
+		return false, nil
+	}
+	return kv.IsDerivedTx(common.BytesToHash(bz))
+}
+
+// indexDerivedTxs indexes the derived EVM transactions carried as events inside a
+// non-eth Cosmos tx (e.g. a Universal Executor MsgExecutePayload). Each derived tx is
+// stored by hash and by (height, ethTxIndex) using the same schema as standard
+// MsgEthereumTx entries, so eth_getTransactionByHash / Receipt and block-and-index
+// lookups resolve it directly without depending on a CometBFT tx_search fallback.
+//
+// ethTxIndex is the shared, block-level eth tx counter; it is advanced once per derived
+// tx and returned so the caller's sequence stays aligned with the txIndex the keeper
+// emits for both derived and standard txs.
+func (kv *KVIndexer) indexDerivedTxs(
+	batch dbm.Batch,
+	height int64,
+	txIndex uint32,
+	result *abci.ExecTxResult,
+	ethTxIndex int32,
+) (int32, error) {
+	// nil tx: ParseTxResult only needs it for the failed-cosmos-tx gas fallback, which
+	// assumes embedded MsgEthereumTx messages and does not apply to derived txs.
+	txs, err := rpctypes.ParseTxResult(result, nil)
+	if err != nil {
+		return ethTxIndex, err
+	}
+
+	var cumulativeGasUsed uint64
+	for _, parsed := range txs.Txs {
+		if parsed.Type != evmtypes.DerivedTxType {
+			continue
+		}
+
+		if parsed.EthTxIndex >= 0 && parsed.EthTxIndex != ethTxIndex {
+			kv.logger.Error("derived eth tx index doesn't match", "expect", ethTxIndex, "found", parsed.EthTxIndex)
+		}
+
+		cumulativeGasUsed += parsed.GasUsed
+		txResult := servertypes.TxResult{
+			Height:            height,
+			TxIndex:           txIndex,
+			MsgIndex:          uint32(parsed.MsgIndex), //#nosec G115 -- int overflow is not a concern here
+			EthTxIndex:        ethTxIndex,
+			Failed:            parsed.Failed,
+			GasUsed:           parsed.GasUsed,
+			CumulativeGasUsed: cumulativeGasUsed,
+		}
+		ethTxIndex++
+
+		if err := saveTxResult(kv.clientCtx.Codec, batch, parsed.Hash, &txResult); err != nil {
+			return ethTxIndex, errorsmod.Wrapf(err, "indexDerivedTxs %d", height)
+		}
+		// Mark the hash as derived in the same batch, so it commits atomically with the
+		// tx-hash/tx-index entries: a derived tx is findable iff its marker exists.
+		if err := batch.Set(DerivedTxHashKey(parsed.Hash), []byte{1}); err != nil {
+			return ethTxIndex, errorsmod.Wrapf(err, "indexDerivedTxs %d set derived key", height)
+		}
+	}
+
+	return ethTxIndex, nil
+}
+
 // TxHashKey returns the key for db entry: `tx hash -> tx result struct`
 func TxHashKey(hash common.Hash) []byte {
 	return append([]byte{KeyPrefixTxHash}, hash.Bytes()...)
+}
+
+// DerivedTxHashKey returns the key for db entry: `tx hash -> derived marker`
+func DerivedTxHashKey(hash common.Hash) []byte {
+	return append([]byte{KeyPrefixTxDerived}, hash.Bytes()...)
 }
 
 // TxIndexKey returns the key for db entry: `(block number, tx index) -> tx hash`

--- a/rpc/backend/comet_to_eth.go
+++ b/rpc/backend/comet_to_eth.go
@@ -397,8 +397,8 @@ func (b *Backend) ReceiptsFromCometBlock(
 
 		var logs []*ethtypes.Log
 		if additional != nil {
-			// Derived tx: MsgIndex is math.MaxUint32 (sentinel). Parse logs from tx_log events
-			// by matching TxHash instead of using the protobuf-encoded Data field.
+			// Derived tx: no MsgEthereumTxResponse in the Cosmos tx Data field.
+			// Parse logs from tx_log ABCI events by matching TxHash instead.
 			logs, err = derivedTxLogsFromEvents(
 				blockRes.TxsResults[txResult.TxIndex].Events,
 				additional.Hash,

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -267,8 +267,8 @@ func (b *Backend) GetTransactionLogs(hash common.Hash) ([]*ethtypes.Log, error) 
 	}
 
 	if additional != nil {
-		// Derived tx: MsgIndex is math.MaxUint32 (sentinel). Parse logs from tx_log events
-		// by matching TxHash instead of using the protobuf-encoded Data field.
+		// Derived tx: no MsgEthereumTxResponse in the Cosmos tx Data field.
+		// Parse logs from tx_log ABCI events by matching TxHash instead.
 		return derivedTxLogsFromEvents(
 			resBlockResult.TxsResults[res.TxIndex].Events,
 			additional.Hash,
@@ -329,16 +329,77 @@ func (b *Backend) GetTransactionByBlockNumberAndIndex(blockNum rpctypes.BlockNum
 	return b.GetTransactionByBlockAndIndex(block, idx)
 }
 
+// derivedTxAdditionalFields rebuilds the TxResultAdditionalFields for a tx located via
+// the KV indexer when (and only when) that tx is a derived EVM tx — an internal execution
+// recorded only as events, with no embedded MsgEthereumTx to decode. The KV indexer stores
+// just the TxResult, so without this the serving paths (GetTransactionByHash / Receipt /
+// TraceTransaction) would treat a derived tx as standard and panic on the MsgEthereumTx
+// cast. Standard txs return (nil, nil); the IsDerivedTx marker gate keeps their lookups
+// cheap (one key read, no event reparse).
+func (b *Backend) derivedTxAdditionalFields(hash common.Hash, res *servertypes.TxResult) (*rpctypes.TxResultAdditionalFields, error) {
+	derived, err := b.Indexer.IsDerivedTx(hash)
+	if err != nil {
+		return nil, err
+	}
+	if !derived {
+		return nil, nil
+	}
+	return b.buildDerivedAdditional(res)
+}
+
+// buildDerivedAdditional re-parses the block events for res's Cosmos tx and rebuilds the
+// TxResultAdditionalFields for the derived EVM tx at res.MsgIndex. Callers must have
+// already confirmed the entry is derived via a marker (IsDerivedTx for the by-hash path,
+// IsDerivedTxByBlockAndIndex for the by-block-index path), so a missing or non-derived
+// parse result is treated as an error.
+func (b *Backend) buildDerivedAdditional(res *servertypes.TxResult) (*rpctypes.TxResultAdditionalFields, error) {
+	blockRes, err := b.RPCClient.BlockResults(b.Ctx, &res.Height)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err, "block results for derived tx at height %d", res.Height)
+	}
+	if int(res.TxIndex) >= len(blockRes.TxsResults) {
+		return nil, fmt.Errorf("derived tx index %d out of bounds at height %d", res.TxIndex, res.Height)
+	}
+
+	parsedTxs, err := rpctypes.ParseTxResult(blockRes.TxsResults[res.TxIndex], nil)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err, "parse derived tx events at height %d", res.Height)
+	}
+	parsed := parsedTxs.GetTxByMsgIndex(int(res.MsgIndex))
+	if parsed == nil || parsed.Type != evmtypes.DerivedTxType {
+		return nil, fmt.Errorf("derived tx not found in events: height %d, txIndex %d, msgIndex %d",
+			res.Height, res.TxIndex, res.MsgIndex)
+	}
+
+	return &rpctypes.TxResultAdditionalFields{
+		Value:     parsed.Amount,
+		Hash:      parsed.Hash,
+		TxHash:    parsed.TxHash,
+		Type:      parsed.Type,
+		Recipient: parsed.Recipient,
+		Sender:    parsed.Sender,
+		GasUsed:   parsed.GasUsed,
+		Data:      parsed.Data,
+		Nonce:     parsed.Nonce,
+		GasLimit:  &parsed.GasLimit,
+	}, nil
+}
+
 // GetTxByEthHash uses `/tx_query` to find transaction by ethereum tx hash
 // TODO: Don't need to convert once hashing is fixed on CometBFT
 // https://github.com/cometbft/cometbft/issues/6539
 func (b *Backend) GetTxByEthHash(hash common.Hash) (*servertypes.TxResult, *rpctypes.TxResultAdditionalFields, error) {
 	if b.Indexer != nil {
 		txRes, err := b.Indexer.GetByTxHash(hash)
-		if err != nil {
-			return nil, nil, err
+		if err == nil {
+			// Indexer hit: rebuild additional fields when this is a derived tx.
+			additional, derr := b.derivedTxAdditionalFields(hash, txRes)
+			if derr != nil {
+				return nil, nil, derr
+			}
+			return txRes, additional, nil
 		}
-		return txRes, nil, nil
+		// Indexer miss — fall through to CometBFT tx_search for derived tx reconstruction.
 	}
 
 	// fallback to CometBFT tx indexer
@@ -355,10 +416,15 @@ func (b *Backend) GetTxByEthHash(hash common.Hash) (*servertypes.TxResult, *rpct
 func (b *Backend) GetTxByEthHashAndMsgIndex(hash common.Hash, index int) (*servertypes.TxResult, *rpctypes.TxResultAdditionalFields, error) {
 	if b.Indexer != nil {
 		txRes, err := b.Indexer.GetByTxHash(hash)
-		if err != nil {
-			return nil, nil, err
+		if err == nil {
+			// Indexer hit: rebuild additional fields when this is a derived tx.
+			additional, derr := b.derivedTxAdditionalFields(hash, txRes)
+			if derr != nil {
+				return nil, nil, derr
+			}
+			return txRes, additional, nil
 		}
-		return txRes, nil, nil
+		// Indexer miss — fall through to CometBFT tx_search for derived tx reconstruction.
 	}
 
 	// fallback to CometBFT tx indexer
@@ -378,6 +444,19 @@ func (b *Backend) GetTxByTxIndex(height int64, index uint) (*servertypes.TxResul
 	if b.Indexer != nil {
 		txRes, err := b.Indexer.GetByBlockAndIndex(height, int32Index)
 		if err == nil {
+			// Only derived block-index entries need their additional fields rebuilt (so
+			// trace predecessors reconstruct them instead of treating them as standard).
+			derived, derr := b.Indexer.IsDerivedTxByBlockAndIndex(height, int32Index)
+			if derr != nil {
+				return nil, nil, derr
+			}
+			if derived {
+				additional, aerr := b.buildDerivedAdditional(txRes)
+				if aerr != nil {
+					return nil, nil, aerr
+				}
+				return txRes, additional, nil
+			}
 			return txRes, nil, nil
 		}
 	}

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -446,6 +446,14 @@ func (m *MockIndexer) GetByBlockAndIndex(blockNumber int64, txIndex int32) (*ser
 	return nil, nil
 }
 
+func (m *MockIndexer) IsDerivedTx(hash common.Hash) (bool, error) {
+	return false, nil
+}
+
+func (m *MockIndexer) IsDerivedTxByBlockAndIndex(blockNumber int64, txIndex int32) (bool, error) {
+	return false, nil
+}
+
 func TestReceiptsFromCometBlock(t *testing.T) {
 	backend := setupMockBackend(t)
 	height := int64(100)

--- a/server/types/indexer.go
+++ b/server/types/indexer.go
@@ -17,4 +17,8 @@ type EVMTxIndexer interface {
 	GetByTxHash(common.Hash) (*TxResult, error)
 	// GetByBlockAndIndex returns nil if tx not found.
 	GetByBlockAndIndex(int64, int32) (*TxResult, error)
+	// IsDerivedTx reports whether the hash was indexed as a derived (event-only) EVM tx.
+	IsDerivedTx(common.Hash) (bool, error)
+	// IsDerivedTxByBlockAndIndex reports whether the tx at (height, eth tx index) is derived.
+	IsDerivedTxByBlockAndIndex(int64, int32) (bool, error)
 }


### PR DESCRIPTION
# Description
# KV Indexer: Derived Tx Support — Design and Port Notes

## Background

**Finding**: F-2026-17740 — *KV indexer path misses derived transactions*

The KV indexer (`indexer/kv_indexer.go`) skipped all non-eth Cosmos transactions during `IndexBlock`. Derived EVM txs — internal EVM executions triggered by Cosmos messages (e.g., IBC transfers, Universal Executor payloads) that emit `ethereum_tx` and `tx_log` ABCI events but carry no embedded `MsgEthereumTx` — were therefore invisible to the indexer.

When a client queried `eth_getTransactionByHash` or `eth_getTransactionReceipt` for a derived tx hash while the KV indexer was active, the lookup returned an error immediately instead of falling through to the CometBFT `tx_search` path. The derived tx was unreachable via the JSON-RPC API even though it existed on chain.

The original fix was authored on the `audit-fixes` branch (targeting the 0.2.0 architecture). This document describes how the fix works and what changed when porting it to the 0.5.0 architecture on `audit/evm-merge-kv-index`.

---

## How the Fix Works

### 1. KV indexer: index derived txs during `IndexBlock`

`IndexBlock` iterates every Cosmos tx in a block. Previously, non-eth txs hit `continue` immediately. The fix inserts a call to `indexDerivedTxs` before that `continue`:

```go
if !isEthTx(tx) {
    ethTxIndex, err = kv.indexDerivedTxs(batch, height, uint32(txIndex), result, ethTxIndex)
    if err != nil {
        kv.logger.Error("Fail to index derived txs", ...)
    }
    continue
}
```

`indexDerivedTxs` calls `rpctypes.ParseTxResult(result, nil)` (passing `nil` for the SDK tx because there is no embedded `MsgEthereumTx` to decode) and iterates the parsed entries looking for `DerivedTxType`. For each one:

- A `TxResult` is written via `saveTxResult` (same schema as native txs: hash key + block-index key).
- A separate marker key `DerivedTxHashKey(hash)` is written in the same batch, committing atomically.
- The shared `ethTxIndex` counter is incremented once per derived tx — keeping it aligned with the counter the keeper emits for both derived and standard txs in the same block (fixed by F-2026-17745).

### 2. New marker key and `IsDerivedTx` / `IsDerivedTxByBlockAndIndex`

A third key prefix is added alongside `KeyPrefixTxHash = 1` and `KeyPrefixTxIndex = 2`:

```go
KeyPrefixTxDerived = 3
```

`DerivedTxHashKey(hash)` returns `[]byte{3} + hash.Bytes()`. The value is a single sentinel byte `{1}`.

Two new interface methods gate the (more expensive) event-reparse behind a single cheap key read:

- `IsDerivedTx(hash)` — checks `DerivedTxHashKey(hash)` directly.
- `IsDerivedTxByBlockAndIndex(height, txIndex)` — reads the block-index entry to get the hash, then delegates to `IsDerivedTx`. Two key reads total.

### 3. RPC backend: rebuild `TxResultAdditionalFields` on KV hit

The KV indexer stores only `TxResult` (height, txIndex, msgIndex, ethTxIndex, gasUsed, failed). For standard txs this is enough — callers decode the `MsgEthereumTx` directly from the block. For derived txs there is no `MsgEthereumTx` to decode; the RPC backend panics trying to cast.

`derivedTxAdditionalFields(hash, res)` solves this:
1. Calls `IsDerivedTx(hash)` — returns `(nil, nil)` cheaply for standard txs.
2. If derived, delegates to `buildDerivedAdditional(res)`, which:
   - Fetches `BlockResults` for `res.Height`.
   - Calls `ParseTxResult` on the relevant `TxsResults[res.TxIndex]` entry.
   - Retrieves the parsed tx by `res.MsgIndex` (the positional index stored during indexing).
   - Constructs a full `TxResultAdditionalFields` from the parsed event fields.

`GetTxByEthHash` and `GetTxByEthHashAndMsgIndex` call `derivedTxAdditionalFields` on every KV hit and return the result alongside the `TxResult`. `GetTxByTxIndex` uses `IsDerivedTxByBlockAndIndex` then `buildDerivedAdditional` on the block-index path, so trace predecessors are reconstructed correctly.

### 4. KV miss: fall through to CometBFT `tx_search`

Before the fix, a KV indexer error on lookup immediately propagated to the caller. After the fix, `err != nil` on a KV lookup is treated as a miss and falls through to the CometBFT `tx_search` path. This preserves correctness for blocks indexed before the fix was deployed — derived txs in those blocks have no KV entries but are still reachable via event-based search.

---

## Differences Between 0.2.0 (`audit-fixes`) and 0.5.0 (`audit/evm-merge-kv-index`)

### Type and package renames

| Concern | 0.2.0 (`audit-fixes`) | 0.5.0 (`audit/evm-merge-kv-index`) |
|---|---|---|
| `TxResult` type | `cosmosevmtypes.TxResult` (from `github.com/cosmos/evm/types`) | `servertypes.TxResult` (from `github.com/cosmos/evm/server/types`) |
| `EVMTxIndexer` interface file | `types/indexer.go` | `server/types/indexer.go` |
| Interface compile-guard | `var _ cosmosevmtypes.EVMTxIndexer = &KVIndexer{}` | `var _ servertypes.EVMTxIndexer = &KVIndexer{}` |

In 0.5.0 the monolithic `types/` package was split and server-specific types (including `TxResult` and `EVMTxIndexer`) moved under `server/types/`. The indexer imports and struct constructors were updated accordingly.

### Backend receiver field names

The `Backend` struct in 0.2.0 uses unexported fields; 0.5.0 promotes them to exported:

| Field | 0.2.0 | 0.5.0 |
|---|---|---|
| RPC client | `b.rpcClient` | `b.RPCClient` |
| Context | `b.ctx` | `b.Ctx` |
| KV indexer | `b.indexer` | `b.Indexer` |

All three appear in `buildDerivedAdditional` and the `GetTxBy*` lookup functions. Every reference was updated.

### `buildDerivedAdditional` factored out as a separate function

In 0.2.0, `derivedTxAdditionalFields` contained both the `IsDerivedTx` marker check **and** the full `BlockResults` + `ParseTxResult` reconstruction logic in a single function.

In 0.5.0, the reconstruction logic was extracted into `buildDerivedAdditional`. `derivedTxAdditionalFields` now only does the `IsDerivedTx` gate and delegates to `buildDerivedAdditional`. This is required because `GetTxByTxIndex` uses `IsDerivedTxByBlockAndIndex` (not `IsDerivedTx`) and needs to call the reconstruction step directly without re-doing the marker check.

```
0.2.0:
  derivedTxAdditionalFields(hash, res)
    → IsDerivedTx check + full reconstruction

0.5.0:
  derivedTxAdditionalFields(hash, res)   ← used by GetTxByEthHash paths
    → IsDerivedTx check
    → buildDerivedAdditional(res)

  buildDerivedAdditional(res)            ← used directly by GetTxByTxIndex
    → BlockResults + ParseTxResult + field mapping
```

### `IsDerivedTxByBlockAndIndex` added to the interface

The 0.2.0 commit (`970f1c1b` / `cf0237af`) adds only `IsDerivedTx` to the `EVMTxIndexer` interface. The `IsDerivedTxByBlockAndIndex` method (used by `GetTxByTxIndex`) was added in a subsequent commit in the same PR chain and squashed into the final merge commit `4b0cc66e`.

In 0.5.0, both methods land together in `server/types/indexer.go` from the start, reflecting the complete interface contract.

### CometBFT tx_search fallback — already present in the original

Both the 0.2.0 commit and the 0.5.0 port treat a KV indexer miss as fall-through to `tx_search`. The comment changed from `// indexer miss — fall through to event-query (tx_search) reconstruction` to `// Indexer miss — fall through to CometBFT tx_search for derived tx reconstruction.` The behavior is identical; the 0.5.0 version uses "CometBFT" consistently (Tendermint was renamed).

### Method name: `queryTendermintTxIndexer` → `QueryCometTxIndexer`

The CometBFT fallback in `GetTxByEthHash` calls `b.queryTendermintTxIndexer` in 0.2.0 and `b.QueryCometTxIndexer` in 0.5.0. Same function, renamed as part of the broader Tendermint → CometBFT migration in 0.5.0.

### `MockIndexer` in tests

0.5.0 unit tests (`tx_info_test.go`) use a `MockIndexer` struct. Adding the two new interface methods required two stub implementations:

```go
func (m *MockIndexer) IsDerivedTx(hash common.Hash) (bool, error) { return false, nil }
func (m *MockIndexer) IsDerivedTxByBlockAndIndex(blockNumber int64, txIndex int32) (bool, error) {
    return false, nil
}
```

These are no-ops (always returning `false`) because the mock is used for standard-tx test paths only.

---

## Summary of All Changed Files

| File | Change |
|---|---|
| `indexer/kv_indexer.go` | `KeyPrefixTxDerived` constant; `indexDerivedTxs`; `IsDerivedTx`; `IsDerivedTxByBlockAndIndex`; `DerivedTxHashKey`; `IndexBlock` wired to call `indexDerivedTxs` |
| `server/types/indexer.go` | `IsDerivedTx` and `IsDerivedTxByBlockAndIndex` added to `EVMTxIndexer` interface |
| `rpc/backend/tx_info.go` | `derivedTxAdditionalFields`; `buildDerivedAdditional`; `GetTxByEthHash` KV hit path; `GetTxByEthHashAndMsgIndex` KV hit path; `GetTxByTxIndex` derived-reconstruction branch; KV miss fall-through on all three |
| `rpc/backend/tx_info_test.go` | `IsDerivedTx` and `IsDerivedTxByBlockAndIndex` stubs added to `MockIndexer` |


Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
