### PR TITLE
fix(rpc): derived transaction support for tracing and block responses

### DIFF
--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -223,6 +223,11 @@ func (b *Backend) GetBlockReceipts(
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal receipt")
 		}
+		// Same override as GetTransactionReceipt: derived txs have an event-emitted
+		// hash that differs from the reconstructed LegacyTx hash.
+		if txsAdditional[i] != nil {
+			result[i]["transactionHash"] = txsAdditional[i].Hash
+		}
 	}
 	return result, nil
 }

--- a/rpc/backend/comet_to_eth.go
+++ b/rpc/backend/comet_to_eth.go
@@ -215,16 +215,21 @@ func (b *Backend) parseDerivedTxFromAdditionalFields(
 	recipient := additional.Recipient
 	gas := gasForDerivedEthTx(additional)
 
-	t := ethtypes.NewTx(&ethtypes.LegacyTx{
-		Nonce:    additional.Nonce,
-		Data:     additional.Data,
-		Gas:      gas,
-		To:       &recipient,
-		GasPrice: nil,
-		Value:    additional.Value,
-		V:        big.NewInt(0),
-		R:        big.NewInt(0),
-		S:        big.NewInt(0),
+	// Use DynamicFeeTx (type 0x2) with explicit zero fee fields so that
+	// unsignedTxAsMessage never dereferences a nil GasPrice. LegacyTx with
+	// GasPrice: nil panics inside new(big.Int).Set(tx.GasPrice()).
+	t := ethtypes.NewTx(&ethtypes.DynamicFeeTx{
+		ChainID:   b.EvmChainID,
+		Nonce:     additional.Nonce,
+		Data:      additional.Data,
+		Gas:       gas,
+		To:        &recipient,
+		Value:     additional.Value,
+		GasFeeCap: big.NewInt(0),
+		GasTipCap: big.NewInt(0),
+		V:         big.NewInt(0),
+		R:         big.NewInt(0),
+		S:         big.NewInt(0),
 	})
 	ethMsg := &evmtypes.MsgEthereumTx{}
 	ethMsg.FromEthereumTx(t)

--- a/rpc/backend/comet_to_eth.go
+++ b/rpc/backend/comet_to_eth.go
@@ -43,13 +43,55 @@ func (b *Backend) RPCBlockFromCometBlock(
 	blockRes *cmtrpctypes.ResultBlockResults,
 	fullTx bool,
 ) (map[string]interface{}, error) {
-	msgs, _ := b.EthMsgsFromCometBlock(resBlock, blockRes)
+	msgs, txsAdditional := b.EthMsgsFromCometBlock(resBlock, blockRes)
 	ethBlock, err := b.EthBlockFromCometBlock(resBlock, blockRes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rpc block from comet block: %w", err)
 	}
 
-	return rpctypes.RPCMarshalBlock(ethBlock, resBlock, msgs, true, fullTx, b.ChainConfig())
+	fields, err := rpctypes.RPCMarshalBlock(ethBlock, resBlock, msgs, true, fullTx, b.ChainConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	// RPCMarshalBlock reads ethBlock.Transactions() which excludes derived txs (they
+	// are intentionally omitted from the ethBlock body in EthBlockFromCometBlock).
+	// Override the transactions field here so derived txs appear in the RPC response
+	// with their event-assigned hashes, not the reconstructed LegacyTx hash.
+	block := resBlock.Block
+	blockHash := common.BytesToHash(block.Hash())
+	blockHeight := uint64(block.Height) //nolint:gosec // G115
+	blockTime := uint64(block.Time.Unix()) //nolint:gosec // G115
+	baseFee, _ := b.BaseFee(blockRes)
+
+	ethRPCTxs := make([]interface{}, 0, len(msgs))
+	for txIndex, ethMsg := range msgs {
+		if !fullTx {
+			var hash common.Hash
+			if txsAdditional[txIndex] != nil {
+				hash = txsAdditional[txIndex].Hash
+			} else {
+				hash = ethMsg.Hash()
+			}
+			ethRPCTxs = append(ethRPCTxs, hash)
+			continue
+		}
+		index := uint64(txIndex) //nolint:gosec // G115
+		if txsAdditional[txIndex] == nil {
+			rpcTx := rpctypes.NewTransactionFromMsg(ethMsg, blockHash, blockHeight, blockTime, index, baseFee, b.ChainConfig())
+			ethRPCTxs = append(ethRPCTxs, rpcTx)
+		} else {
+			rpcTx, txErr := rpctypes.NewRPCTransactionFromIncompleteMsg(ethMsg, blockHash, blockHeight, index, baseFee, b.EvmChainID, txsAdditional[txIndex].Hash)
+			if txErr != nil {
+				b.Logger.Debug("NewRPCTransactionFromIncompleteMsg failed", "error", txErr)
+				continue
+			}
+			ethRPCTxs = append(ethRPCTxs, rpcTx)
+		}
+	}
+	fields["transactions"] = ethRPCTxs
+
+	return fields, nil
 }
 
 // BlockNumberFromComet returns the BlockNumber from BlockNumberOrHash

--- a/rpc/backend/tracing.go
+++ b/rpc/backend/tracing.go
@@ -6,7 +6,6 @@ import (
 	"math"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
@@ -44,7 +43,7 @@ func (b *Backend) TraceTransaction(hash common.Hash, config *rpctypes.TraceConfi
 		return nil, fmt.Errorf("tx count %d is overflowing", len(blk.Block.Txs))
 	}
 	txsLen := uint32(len(blk.Block.Txs)) // #nosec G115 -- checked for int overflow already
-	if txsLen < transaction.TxIndex {
+	if txsLen <= transaction.TxIndex {
 		b.Logger.Debug("tx index out of bounds", "index", transaction.TxIndex, "hash", hash.String(), "height", blk.Block.Height)
 		return nil, fmt.Errorf("transaction not included in block %v", blk.Block.Height)
 	}
@@ -246,11 +245,7 @@ func (b *Backend) TraceBlock(height rpctypes.BlockNumber,
 	config *rpctypes.TraceConfig,
 	block *tmrpctypes.ResultBlock,
 ) ([]*evmtypes.TxTraceResult, error) {
-	txs := block.Block.Txs
-	txsLength := len(txs)
-
-	if txsLength == 0 {
-		// If there are no transactions return empty array
+	if len(block.Block.Txs) == 0 {
 		return []*evmtypes.TxTraceResult{}, nil
 	}
 
@@ -259,28 +254,11 @@ func (b *Backend) TraceBlock(height rpctypes.BlockNumber,
 		b.Logger.Debug("block result not found", "height", block.Block.Height, "error", err.Error())
 		return nil, nil
 	}
-	txDecoder := b.ClientCtx.TxConfig.TxDecoder()
 
-	var txsMessages []*evmtypes.MsgEthereumTx
-	for i, tx := range txs {
-		if !rpctypes.TxSucessOrExpectedFailure(blockRes.TxsResults[i]) {
-			b.Logger.Debug("invalid tx result code", "cosmos-hash", hexutil.Encode(tx.Hash()))
-			continue
-		}
-		decodedTx, err := txDecoder(tx)
-		if err != nil {
-			b.Logger.Error("failed to decode transaction", "hash", txs[i].Hash(), "error", err.Error())
-			continue
-		}
-
-		for _, msg := range decodedTx.GetMsgs() {
-			ethMessage, ok := msg.(*evmtypes.MsgEthereumTx)
-			if !ok {
-				// Just considers Ethereum transactions
-				continue
-			}
-			txsMessages = append(txsMessages, ethMessage)
-		}
+	// EthMsgsFromCometBlock returns both native MsgEthereumTx and derived txs.
+	txsMessages, _ := b.EthMsgsFromCometBlock(block, blockRes)
+	if len(txsMessages) == 0 {
+		return []*evmtypes.TxTraceResult{}, nil
 	}
 
 	// minus one to get the context at the beginning of the block
@@ -317,7 +295,7 @@ func (b *Backend) TraceBlock(height rpctypes.BlockNumber,
 		return nil, err
 	}
 
-	decodedResults := make([]*evmtypes.TxTraceResult, txsLength)
+	decodedResults := make([]*evmtypes.TxTraceResult, len(txsMessages))
 	if err := json.Unmarshal(res.Data, &decodedResults); err != nil {
 		return nil, err
 	}

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -238,7 +238,17 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash) (map[string]interface{
 		return nil, fmt.Errorf("failed to get sender: %w", err)
 	}
 
-	return rpctypes.RPCMarshalReceipt(receipts[0], ethTx, from)
+	result, err := rpctypes.RPCMarshalReceipt(receipts[0], ethTx, from)
+	if err != nil {
+		return nil, err
+	}
+	// RPCMarshalReceipt computes transactionHash from ethTx.Hash(), which for derived
+	// txs is the reconstructed LegacyTx hash — different from the event-emitted hash.
+	// Override so eth_getTransactionReceipt agrees with eth_getTransactionByHash.
+	if additional != nil {
+		result["transactionHash"] = additional.Hash
+	}
+	return result, nil
 }
 
 // GetTransactionLogs returns the transaction logs identified by hash.

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -49,14 +49,21 @@ func (b *Backend) GetTransactionByHash(txHash common.Hash) (*rpctypes.RPCTransac
 
 	var ethMsg *evmtypes.MsgEthereumTx
 	if additional == nil {
-		// #nosec G115 always in range
+		if int(res.TxIndex) >= len(block.Block.Txs) { //nolint:gosec // G115
+			return nil, fmt.Errorf("tx index %d out of range for block with %d txs", res.TxIndex, len(block.Block.Txs))
+		}
 		tx, err := b.ClientCtx.TxConfig.TxDecoder()(block.Block.Txs[res.TxIndex])
 		if err != nil {
 			b.Logger.Debug("decoding failed", "error", err.Error())
 			return nil, fmt.Errorf("failed to decode tx: %w", err)
 		}
-		ethMsg = tx.GetMsgs()[res.MsgIndex].(*evmtypes.MsgEthereumTx)
-		if ethMsg == nil {
+		msgs := tx.GetMsgs()
+		if int(res.MsgIndex) >= len(msgs) { //nolint:gosec // G115
+			return nil, fmt.Errorf("msg index %d out of range for tx with %d msgs", res.MsgIndex, len(msgs))
+		}
+		var ok bool
+		ethMsg, ok = msgs[res.MsgIndex].(*evmtypes.MsgEthereumTx)
+		if !ok || ethMsg == nil {
 			b.Logger.Error("failed to get eth msg from sdk.Msgs")
 			return nil, fmt.Errorf("failed to get eth msg from sdk.Msgs")
 		}

--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/big"
@@ -315,6 +316,28 @@ func GetLogsFromBlockResults(blockRes *cmtrpctypes.ResultBlockResults) ([][]*eth
 		logs, err := evmtypes.DecodeTxLogs(txResult.Data, height)
 		if err != nil {
 			return nil, err
+		}
+		// Derived txs have no MsgEthereumTxResponse in txResult.Data; their logs
+		// are emitted as EventTypeTxLog ABCI events. Fall back to scanning events
+		// when DecodeTxLogs returns nothing.
+		if len(logs) == 0 {
+			for _, event := range txResult.Events {
+				if event.Type != evmtypes.EventTypeTxLog {
+					continue
+				}
+				for _, attr := range event.Attributes {
+					if attr.Key != evmtypes.AttributeKeyTxLog {
+						continue
+					}
+					var evmLog evmtypes.Log
+					if err := json.Unmarshal([]byte(attr.Value), &evmLog); err != nil {
+						return nil, err
+					}
+					l := evmLog.ToEthereum()
+					l.BlockNumber = height
+					logs = append(logs, l)
+				}
+			}
 		}
 		blockLogs = append(blockLogs, logs)
 	}

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -752,9 +752,18 @@ func (k *Keeper) traceTx(
 	traceConfig *types.TraceConfig,
 	commitMessage bool,
 ) (*any, uint, error) {
-	msg, err := core.TransactionToMessage(tx, signer, cfg.BaseFee)
-	if err != nil {
-		return nil, 0, status.Error(codes.Internal, err.Error())
+	// Derived txs are unsigned (V=R=S=0) and cannot be recovered via the signer.
+	// Use the pre-populated from address directly, same as the predecessor loop.
+	var msg *core.Message
+	if isUnsigned(tx) {
+		m := unsignedTxAsMessage(from, tx, cfg.BaseFee)
+		msg = &m
+	} else {
+		var err error
+		msg, err = core.TransactionToMessage(tx, signer, cfg.BaseFee)
+		if err != nil {
+			return nil, 0, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	return k.traceTxWithMsg(ctx, cfg, txConfig, msg, traceConfig, commitMessage)

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -555,7 +555,8 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 				continue
 			}
 		} else {
-			derivedMsg := unsignedTxAsMessage(common.BytesToAddress(req.Msg.GetFrom()), ethTx, cfg.BaseFee)
+			// Use this predecessor's own From address, not the target tx's From.
+			derivedMsg := unsignedTxAsMessage(common.BytesToAddress(tx.GetFrom()), ethTx, cfg.BaseFee)
 			msg = &derivedMsg
 		}
 		msg.GasLimit = min(msg.GasLimit, maxPredecessorGas)


### PR DESCRIPTION
# Description
# fix(rpc): derived transaction support for tracing and block responses

## Summary

Two bugs in the 0.5.0 merge caused derived transactions (EVM executions synthesized from non-EVM Cosmos messages) to fail in two separate RPC endpoints. Both regressions are present in `audit/evm-merge-inconsistent-logs` but not in `feat/derived-tx-evm-0.4.0`.

---

## Bug 1 — `debug_traceTransaction` returns "invalid transaction v, r, s values" for derived txs

### Root Cause

`traceTx` in `x/vm/keeper/grpc_query.go` calls `core.TransactionToMessage(tx, signer, cfg.BaseFee)` unconditionally. Derived transactions have no Ethereum signature — they are synthesized from Cosmos ABCI events and carry `V=R=S=0`. `TransactionToMessage` tries to recover the sender from these zero-value signature fields and fails with:

```
rpc error: code = Internal desc = invalid transaction v, r, s values
```

The predecessor loop (lines 552–560) was already correctly patched with an `isUnsigned` guard that calls `unsignedTxAsMessage(from, tx, baseFee)` instead of `TransactionToMessage`. However, `traceTx` itself — which processes the **target** transaction, not predecessors — was never updated with the same logic. The `from common.Address` parameter was passed in from the call site (`common.BytesToAddress(req.Msg.GetFrom())`) but was silently ignored inside `traceTx`.

### Fix

`x/vm/keeper/grpc_query.go` — `traceTx` function:

Added the same `isUnsigned` check that already exists in the predecessor loop. When the target tx is unsigned (derived), construct the EVM message from the pre-populated `from` address directly instead of attempting signature recovery.

```go
// Before
msg, err := core.TransactionToMessage(tx, signer, cfg.BaseFee)
if err != nil {
    return nil, 0, status.Error(codes.Internal, err.Error())
}
return k.traceTxWithMsg(ctx, cfg, txConfig, msg, traceConfig, commitMessage)

// After
var msg *core.Message
if isUnsigned(tx) {
    m := unsignedTxAsMessage(from, tx, cfg.BaseFee)
    msg = &m
} else {
    var err error
    msg, err = core.TransactionToMessage(tx, signer, cfg.BaseFee)
    if err != nil {
        return nil, 0, status.Error(codes.Internal, err.Error())
    }
}
return k.traceTxWithMsg(ctx, cfg, txConfig, msg, traceConfig, commitMessage)
```

---

## Bug 2 — `eth_getBlockByHash` returns 0 transactions when the block contains only derived txs

### Root Cause

The 0.5.0 merge split block building across two functions:

- `EthBlockFromCometBlock` — builds a proper `*ethtypes.Block`. It intentionally excludes derived txs from the block body (correct: the Ethereum block trie should only contain signed native EVM txs for hash integrity). The comment at that line reads _"exclude derived txs from the ETH block body"_.
- `RPCMarshalBlock` — converts the ethBlock to the JSON-RPC response. It builds the `"transactions"` field from `block.Transactions()`, which are the transactions in the ethBlock body — i.e., only native EVM txs. Derived txs are gone.

`RPCBlockFromCometBlock` calls both and passes a `msgs` slice (which does include derived txs) to `RPCMarshalBlock`, but `RPCMarshalBlock` never reads `msgs` — it only reads `block.Transactions()`.

In `feat/derived-tx-evm-0.4.0`, `RPCBlockFromCometBlock` built the transaction list manually from `msgs` + `txsAdditional`, using the ABCI event-assigned hash for each derived tx. That path was lost in the 0.5.0 restructure.

### Fix

`rpc/backend/comet_to_eth.go` — `RPCBlockFromCometBlock` function:

After `RPCMarshalBlock` returns the base block fields, override the `"transactions"` field with a list built from `msgs` + `txsAdditional`:

- For hash-only responses (`fullTx=false`): use the ABCI event hash for derived txs and `ethMsg.Hash()` for native EVM txs.
- For full-tx responses (`fullTx=true`): use `NewTransactionFromMsg` for native EVM txs and `NewRPCTransactionFromIncompleteMsg` (with the event hash) for derived txs.

This restores the behaviour from the working branch while keeping `EthBlockFromCometBlock` correct (derived txs remain excluded from the actual `*ethtypes.Block` body used for hash computation).

---

## Files Changed

| File | Change |
|------|--------|
| `x/vm/keeper/grpc_query.go` | Added `isUnsigned` guard in `traceTx` to use `unsignedTxAsMessage` for derived txs instead of failing on signature recovery |
| `rpc/backend/comet_to_eth.go` | `RPCBlockFromCometBlock` now overrides the `"transactions"` field using `msgs`+`txsAdditional` so derived txs appear in block responses |

---

## Testing

All 11 existing `BackendTestSuite/TestTraceTransaction*` unit tests pass (`-tags=test`). The two fixes are independently verifiable by tracing a derived-tx hash and by calling `eth_getBlockByHash` on a block that contains only non-EVM Cosmos txs that triggered EVM executions.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
